### PR TITLE
Configurable log output.

### DIFF
--- a/canmatrix/autosarhelper.py
+++ b/canmatrix/autosarhelper.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 from builtins import *
 #!/usr/bin/env python
+
+import logging
+logger = logging.getLogger('root')
 from .canmatrix import *
 
 #Copyright (c) 2013, Eduard Broecker
@@ -77,7 +80,7 @@ def arGetPath(ardict, path):
 
 
 def arGetChild(parent, tagname, arTranslationTable, namespace):
-#       print "getChild: " + tagname
+    logger.debug("getChild: " + tagname)
     if parent is None:
         return None
     ret = parent.find('./' + namespace + tagname)

--- a/canmatrix/convert.py
+++ b/canmatrix/convert.py
@@ -23,17 +23,17 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from .log import setup_logger, set_log_level
+logger = setup_logger('root')
 import sys
 sys.path.append('..')
-
-import canmatrix.exportall as ex
-import canmatrix.importall as im
-import canmatrix.canmatrix as cm
 import os
 
 def convert(infile, outfileName, **options):
+    import canmatrix.exportall as ex
+    import canmatrix.importall as im
     dbs = {}
-    print("Importing " + infile + " ... ")
+    logger.info("Importing " + infile + " ... ")
     if infile[-3:] == 'dbc':
         dbs[""] = im.importDbc(infile, **options)
     elif infile[-3:] == 'dbf':
@@ -51,16 +51,16 @@ def convert(infile, outfileName, **options):
     elif infile[-4:] == 'yaml':
         dbs[""] = im.importYaml(infile)
     else:
-        sys.stderr.write('\nFile not recognized: ' + infile + "\n")
-    print("done\n")
+        logger.error('\nFile not recognized: ' + infile + "\n")
+    logger.info("done\n")
 
 
-    print("Exporting " + outfileName + " ... ")
+    logger.info("Exporting " + outfileName + " ... ")
 
     for name in dbs:
         db = dbs[name]
-        print(name)
-        print("%d Frames found" % (db._fl._list.__len__()))
+        logger.info(name)
+        logger.info("%d Frames found" % (db._fl._list.__len__()))
 
         if len(name) > 0:
             path = os.path.split(outfileName)
@@ -88,8 +88,8 @@ def convert(infile, outfileName, **options):
         elif outfile[-3:] == 'csv':
             ex.exportCsv(db, outfile)
         else:
-            sys.stderr.write('File not recognized: ' + outfileName + "\n")
-    print("done")
+            logger.error('File not recognized: ' + outfileName + "\n")
+    logger.info("done")
 
 def main():
     from optparse import OptionParser
@@ -106,6 +106,8 @@ def main():
     #parser.add_option("-d", "--debug",
     #                  dest="debug", default=False,
     #                  help="print debug messages to stdout")
+    parser.add_option("-v", dest="verbosity", action="count", help="Output verbosity", default=0)
+    parser.add_option("-s", dest="silent", action="store_true", help="don't print status messages to stdout. (only errors)", default=False)
     parser.add_option("", "--arxmlIgnoreClusterInfo",
                                       dest="arxmlIgnoreClusterInfo", default=0,
                                       help="Ignore any can cluster info from arxml; Import all frames in one matrix\ndefault 0")
@@ -137,14 +139,21 @@ def main():
                                       dest="xlsMotorolaBitFormat", default="msbreverse",
                                       help="Excel format for startbit of motorola codescharset signals\nValid values: msb, lsb, msbreverse\n default msbreverse")
 
-
     (cmdlineOptions, args) = parser.parse_args()
     if len(args) < 2:
         parser.print_help()
         sys.exit(1)
+
     infile = args[0]
     outfileName = args[1]
 
+    verbosity = cmdlineOptions.verbosity
+    if cmdlineOptions.silent:
+        # only print error messages, ignore verbosity flag
+        verbosity = -1
+ 
+    set_log_level(logger, verbosity)
+   
     convert(infile, outfileName, **cmdlineOptions.__dict__)
 
 if __name__ == '__main__':

--- a/canmatrix/exportall.py
+++ b/canmatrix/exportall.py
@@ -1,39 +1,56 @@
 #!/usr/bin/env python
 from __future__ import print_function
 from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger('root')
+
 from .exportdbc import *
 from .exportdbf import *
 from .exportsym import *
 from .exportJson import *
 from .exportcsv import *
 
+
 try:
     from .exportarxml import *
 except:
-    print("no arxml-export-support, some dependencys missing... try pip install lxml")
+    logger.warn("no arxml-export-support, some dependencies missing... try pip install lxml")
 
 try:
     from .exportkcd import *
 except:
-    print("no kcd-export-support, some dependencys missing...  try pip install lxml")
+    logger.warn("no kcd-export-support, some dependenies missing...  try pip install lxml")
+
 try:
     from .exportsym import *
 except:
-    print("no sym-export-support, some dependencys missing... ")
-
+    logger.warn("no sym-export-support, some dependencies missing... ")
 
 try:
     from .exportxls import *
 except:
-    print("no xls-export-support, some dependencys missing...  try pip install xlwt")
+    logger.warn("no xls-export-support, some dependencies missing...  try pip install xlwt")
+
 try:
     from .exportxlsx import *
 except:
-    print("no xlsx-export-support, some dependencys missing...  try pip install xlswriter")
+    logger.warn("no xlsx-export-support, some dependencies missing...  try pip install xlswriter")
+
 try:
     from .exportyaml import *
 except:
-    print("no yaml-export-support, some dependencys missing ...  try pip install pyyaml ")
+    logger.warn("no yaml-export-support, some dependencies missing ...  try pip install pyyaml ")
+
+try:
+    from .exportxlsx import *
+except:
+    logger.warn("no xlsx-export-support, some dependencies missing... ")
+
+try:
+    from .exportyaml import *
+except:
+    logger.warn("no yaml-export-support, some dependencies missing ... (probably yaml) ")
 
 
 

--- a/canmatrix/importany.py
+++ b/canmatrix/importany.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
 #!/usr/bin/env python
-from . import importall as im
 
 #Copyright (c) 2013, Eduard Broecker
 #All rights reserved.
@@ -24,6 +23,8 @@ from . import importall as im
 #DAMAGE.
 
 def importany(filename):
+    # import within function to disable warning messages by log level
+    from . import importall as im
     db = None
     if filename[-3:] == 'dbc':
         db = im.importDbc(filename)

--- a/canmatrix/importarxml.py
+++ b/canmatrix/importarxml.py
@@ -2,6 +2,10 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger('root')
+
 from builtins import *
 import math
 from lxml import etree
@@ -125,7 +129,7 @@ def getSignals(signalarray, Bo, arDict, ns, multiplexId):
                 const = arGetChild(compuscale, "COMPU-CONST", arDict, ns)
                 # value hinzufuegen
                 if const is None:
-                    print("unknown Compu-Method: " + compmethod.get('UUID'))
+                    logger.warn("unknown Compu-Method: " + compmethod.get('UUID'))
         byteorder = 0
         if motorolla.text == 'MOST-SIGNIFICANT-BYTE-LAST':
             byteorder = 1
@@ -345,21 +349,21 @@ def importArxml(filename, **options):
         ignoreClusterInfo=0
 
     result = {}
-    print("Read arxml ...")
+    logger.debug("Read arxml ...")
     tree = etree.parse(filename)
 
     root = tree.getroot()
-    print(" Done\n")
+    logger.debug(" Done\n")
 
     ns = "{" + tree.xpath('namespace-uri(.)') + "}"
     nsp = tree.xpath('namespace-uri(.)')
 
     topLevelPackages = root.find('./' + ns + 'TOP-LEVEL-PACKAGES')
 
-    print("Build arTree ...")
+    logger.debug("Build arTree ...")
     arDict = arTree()
     arParseTree(topLevelPackages, arDict, ns)
-    print(" Done\n")
+    logger.debug(" Done\n")
 
     ccs = root.findall('.//' + ns + 'CAN-CLUSTER')
     for cc in ccs:
@@ -375,15 +379,15 @@ def importArxml(filename, **options):
         db.addSignalDefines("GenSigStartValue", 'HEX 0 4294967295')
 
         speed = arGetChild(cc, "SPEED", arDict, ns)
-        print("Busname: " + arGetName(cc,ns), end=' ')
+        logger.debug("Busname: " + arGetName(cc,ns), end=' ')
         if speed is not None:
-            print(" Speed: " + speed.text)
+            logger.debug(" Speed: " + speed.text)
 
         physicalChannels = arGetChild(cc, "PHYSICAL-CHANNELS", arDict, ns)
 
         busname = arGetName(cc,ns)
         if speed is not None:
-            print(" Speed: " + speed.text)
+            logger.debug(" Speed: " + speed.text)
 
         nmLowerId = arGetChild(cc, "NM-LOWER-CAN-ID", arDict, ns)
 

--- a/canmatrix/importdbc.py
+++ b/canmatrix/importdbc.py
@@ -1,6 +1,10 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger('root')
+
 from builtins import *
 import math
 #!/usr/bin/env python
@@ -64,7 +68,7 @@ def importDbc(filename, **options):
             try:
                 comment += "\n" + l.decode(dbcCommentEncoding).replace('\\"','"')
             except:
-                print ("Error decoding line: %d (%s)" % (i, line))
+                logger.error("Error decoding line: %d (%s)" % (i, line))
             if l.endswith(b'";'):
                 followUp = FollowUps.nothing
                 if signal is not None:
@@ -74,7 +78,7 @@ def importDbc(filename, **options):
             try:
                 comment += "\n" + l.decode(dbcCommentEncoding).replace('\\"','"')
             except:
-                print ("Error decoding line: %d (%s)" % (i, line))
+                logger.error("Error decoding line: %d (%s)" % (i, line))
             if l.endswith(b'";'):
                 followUp = FollowUps.nothing
                 if frame is not None:
@@ -84,7 +88,7 @@ def importDbc(filename, **options):
             try:
                 comment += "\n" + l.decode(dbcCommentEncoding).replace('\\"','"')
             except:
-                print ("Error decoding line: %d (%s)" % (i, line))
+                logger.error("Error decoding line: %d (%s)" % (i, line))
             if l.endswith(b'";'):
                 followUp = FollowUps.nothing
                 if boardUnit is not None:
@@ -143,7 +147,7 @@ def importDbc(filename, **options):
                     try:
                         signal.addComment(temp_raw.group(3).decode(dbcCommentEncoding).replace('\\"','"'))
                     except:
-                        print ("Error decoding line: %d (%s)" % (i, line))
+                        logger.error("Error decoding line: %d (%s)" % (i, line))
             else:
                 pattern = "^CM\_ SG\_ *(\w+) *(\w+) *\"(.*)"
                 regexp = re.compile(pattern)
@@ -156,7 +160,7 @@ def importDbc(filename, **options):
                     try:
                         comment = temp_raw.group(3).decode(dbcCommentEncoding).replace('\\"','"')
                     except:
-                        print ("Error decoding line: %d (%s)" % (i, line))
+                        logger.error("Error decoding line: %d (%s)" % (i, line))
                     followUp = FollowUps.signalComment
 
         elif decoded.startswith("CM_ BO_ "):
@@ -171,7 +175,7 @@ def importDbc(filename, **options):
                     try:
                         frame.addComment(temp_raw.group(2).decode(dbcCommentEncoding).replace('\\"','"'))
                     except:
-                        print ("Error decoding line: %d (%s)" % (i, line))
+                        logger.error("Error decoding line: %d (%s)" % (i, line))
             else:
                 pattern = "^CM\_ BO\_ *(\w+) *\"(.*)"
                 regexp = re.compile(pattern)
@@ -183,7 +187,7 @@ def importDbc(filename, **options):
                     try:
                         comment = temp_raw.group(2).decode(dbcCommentEncoding).replace('\\"','"')
                     except:
-                        print ("Error decoding line: %d (%s)" % (i, line))
+                        logger.error("Error decoding line: %d (%s)" % (i, line))
                     followUp = FollowUps.frameComment
         elif decoded.startswith("CM_ BU_ "):
             pattern = "^CM\_ BU\_ *(\w+) *\"(.*)\";"
@@ -197,7 +201,7 @@ def importDbc(filename, **options):
                     try:
                         boardUnit.addComment(temp_raw.group(2).decode(dbcCommentEncoding).replace('\\"','"'))
                     except:
-                        print ("Error decoding line: %d (%s)" % (i, line))
+                        logger.error("Error decoding line: %d (%s)" % (i, line))
             else:
                 pattern = "^CM\_ BU\_ *(\w+) *\"(.*)"
                 regexp = re.compile(pattern)
@@ -210,7 +214,7 @@ def importDbc(filename, **options):
                         try:
                             comment = temp_raw.group(2).decode(dbcCommentEncoding).replace('\\"','"')
                         except:
-                            print ("Error decoding line: %d (%s)" % (i, line))
+                            logger.error("Error decoding line: %d (%s)" % (i, line))
                         followUp = FollowUps.boardUnitComment
         elif decoded.startswith("BU_:"):
             pattern = "^BU\_\:(.*)"
@@ -240,7 +244,7 @@ def importDbc(filename, **options):
                         if sg:
                             sg.addValues(tempList[i*2], val)
                 except:
-                    print("Error with Line: ",tempList)
+                    logger.error("Error with Line: " + str(tempList))
 
         elif decoded.startswith("VAL_TABLE_ "):
             regexp = re.compile("^VAL\_TABLE\_ (\w+) (.*);")
@@ -254,10 +258,10 @@ def importDbc(filename, **options):
                         val = tempList[i*2+1]
                         valHash[tempList[i*2].strip()] = val.strip()
                 except:
-                    print("Error with Line: ",tempList)
+                    logger.error("Error with Line: " + str(tempList))
                 db.addValueTable(tableName, valHash)
             else:
-                print(l)
+                logger.debug(l)
 
         elif decoded.startswith("BA_DEF_ SG_ "):
             pattern = "^BA\_DEF\_ SG\_ +\"([A-Za-z0-9\-_]+)\" +(.+);"

--- a/canmatrix/importdbf.py
+++ b/canmatrix/importdbf.py
@@ -27,6 +27,10 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger('root')
+
 from .canmatrix import *
 import re
 import codecs
@@ -49,7 +53,7 @@ def decodeDefine(line):
         myDef = valueType
         default = value
     else:
-        print(line)
+        logger.debug(line)
 
     return define[1:-1], myDef, default
 
@@ -188,7 +192,7 @@ def importDbf(filename, **options):
                 (name, Id, size, nSignals, dummy, extended,transmitter) = temstr.split(',')
                 newBo = db._fl.addFrame(Frame(int(Id), name, size, transmitter))
                 if extended == 'X':
-                    print ("Extended")
+                    logger.debug ("Extended")
                     newBo._extended = 1
 
             if line.startswith("[NODE]"):

--- a/canmatrix/importsym.py
+++ b/canmatrix/importsym.py
@@ -1,5 +1,9 @@
 from __future__ import division
 from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger('root')
+
 from builtins import *
 import math
 #!/usr/bin/env python

--- a/canmatrix/importxls.py
+++ b/canmatrix/importxls.py
@@ -28,6 +28,10 @@
 
 from __future__ import division
 from __future__ import print_function
+
+import logging
+logger = logging.getLogger('root')
+
 from builtins import *
 import math
 from .canmatrix import *
@@ -233,7 +237,7 @@ def importXls(filename, **options):
                 try:
                     newSig._factor = float(factor)
                 except:
-                    print("Some error occured while decoding scale: Signal: %s; \"%s\"" % (signalName, sh.cell(rownum,index['function']).value))
+                    logger.warn("Some error occurred while decoding scale: Signal: %s; \"%s\"" % (signalName, sh.cell(rownum,index['function']).value))
             else:
                 unit = factor.strip()
                 newSig._unit = unit

--- a/canmatrix/log.py
+++ b/canmatrix/log.py
@@ -1,39 +1,5 @@
-#!/usr/bin/env python
-from __future__ import print_function
 from __future__ import absolute_import
-from .importdbc import *
-from .importdbf import *
-from .importsym import *
-
-import logging
-logger = logging.getLogger('root')
-
-
-try:
-    from .importarxml import *
-except:
-    logger.warn("no arxml-import-support, some dependencies missing... , try pip install lxml ")
-
-try:
-    from .importkcd import *
-except:
-    logger.warn("no kcd-import-support, some dependencies missing... , try pip install lxml")
-
-try:
-    from .importxls import *
-except:
-    logger.warn("no xls-import-support, some dependencies missing... , try pip install xlrd xlwt")
-
-try:
-    from .importxlsx import *
-except:
-    logger.warn("no xlsx-import-support, some dependencies missing... , try pip install xlrd ")
-
-try:
-    from .importyaml import *
-except:
-    logger.warn("no yaml-import-support, some dependencies missing ... , try pip install yaml  ")
-
+#!/usr/bin/env python
 
 #Copyright (c) 2013, Eduard Broecker
 #All rights reserved.
@@ -54,3 +20,30 @@ except:
 #CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 #OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 #DAMAGE.
+
+# Configurable logging
+# Author: Martin Hoffmann (m8ddin@gmail.com)
+
+import logging
+
+def setup_logger(name):
+    """Setup a project wide logger singleton"""
+    formatter = logging.Formatter(fmt='%(levelname)s - %(module)s - %(message)s')
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    return logger
+
+def set_log_level(logger, level):
+    """Dynamic reconfiguration of the log level"""
+    if level > 2:
+        level = 2
+    if level < -1:
+        level = -1
+        
+    lvls = {-1: logging.ERROR, 0: logging.WARN, 1: logging.INFO, 2: logging.DEBUG}
+    logger.setLevel(lvls[level])


### PR DESCRIPTION
In order to use the tools also within more complex workflows (e.g., piping results into another commandline tool), making status/debug message outputs configurable would be nice (e.g., disable the import warnings).

This change replaces print statements with categorized logging output (error, warn,
info, debug).
Output verbosity is configurable via command line switch (-s, -v, -vv).
Default level (no switch): only error/warn messages are printed
-s : (silent) only error messages are printed
-v : error/warn/info
-vv: error/warn/info/debug

*Warning* I was not able to test the change with all data formats.
