### PR TITLE
Added all information required for decoding in the exported json file

### DIFF
--- a/canmatrix/exportJson.py
+++ b/canmatrix/exportJson.py
@@ -43,10 +43,18 @@ def exportJson(db, filename):
     exportArray = []
 
     for frame in db._fl._list:
-        signals = {}
+        signals = []
         for signal in frame._signals:
-            signals[signal.getLsbStartbit()]= {"name" : signal._name, "bit_length" : signal._signalsize, "factor":signal._factor, "offset":signal._offset}
+            signals.append({
+                "name" : signal._name,
+                "start_bit" : signal.getLsbStartbit(),
+                "bit_length" : signal._signalsize,
+                "factor":float(signal._factor),
+                "offset":float(signal._offset),
+                "is_big_endian":signal._byteorder == 0,
+                "is_signed":signal._valuetype == "-"
+            })
 
-        exportArray.append({"name" : frame._name, "id" :  hex(frame._Id), "signals": signals })
+        exportArray.append({"name" : frame._name, "id" : int(frame._Id), "signals": signals })
 
     json.dump({"messages" : exportArray}, f, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
Not every information required for parsing was present in the exported json file; also changed the signals into a list; not a dictionary with start bit string keys.