### PR TITLE
Reintroduce Travis testing Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
+  - "2.7"
   - "3.5"
-# command to install dependencies
-install: "pip install -r requirements.txt"
 # command to run tests
 script: source ./test.sh

--- a/canmatrix/exportany.py
+++ b/canmatrix/exportany.py
@@ -20,13 +20,14 @@
 #OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 #DAMAGE.
 
+from __future__ import absolute_import
 import os.path
 import logging
 logger = logging.getLogger('root')
 
 
 def exportany(db, outfile, **options):
-    import canmatrix.exportall as ex
+    from . import exportall as ex
 
     # Get output file extension   
     fileext = '' 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-pip install .[arxml,kcd,fibex,xls,xlsx,yaml]
+pip install -e .[arxml,kcd,fibex,xls,xlsx,yaml]
 cd test
 python ./test.py

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-python setup.py install
+pip install .[arxml,kcd,fibex,xls,xlsx,yaml]
 cd test
-./test.py
+python ./test.py


### PR DESCRIPTION
Since I assume Python 2.7 is still being supported, I think it's a good idea to have Travis test it also. I'm not sure if there was a particular reason for removing that before, but I'm trying to add it again with this pull request.

I also changed the procedure of installing canmatrix and its dependencies to use pip as that is the normal way to do it. This would make requirements.txt unnecessary but I have not deleted it in case it's used somewhere else.