### PR TITLE
Changes for dependency handling

### DIFF
--- a/canmatrix/formats.py
+++ b/canmatrix/formats.py
@@ -17,7 +17,7 @@ for module in moduleList:
         import_module("canmatrix." + module)
         loadedFormats.append(module)
     except ImportError:
-        logger.error("Error importing canmatrix." + module)
+        logger.info("%s is not supported", module)
 
 for loadedModule in loadedFormats:
     supportedFormats[loadedModule] = []
@@ -53,6 +53,7 @@ def loadp(path, importType=None, key="", flatImport=None, **options):
     if importType:
         return load(fileObject, importType, **options)
     else:
+        logger.error("This file format is not supported for reading")
         return None
 
 
@@ -101,5 +102,7 @@ def dumpp(canCluster, path, exportType=None, **options):
                 fileObject = open(outfile, "wb")
                 dump(db, fileObject, exportType, **options)
                 fileObject.close()
+    else:
+        logger.error("This file format is not supported for writing")
 
     return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ lxml
 xlwt
 xlrd
 xlsxwriter
-pyaml
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,6 @@ from canmatrix.version import version
 
 doclines = __doc__.split("\n")
 
-requirements = []
-if sys.version_info < (3, 0):
-    requirements.append("future")
-
 setup(
     name = "canmatrix",
     version = version,
@@ -70,7 +66,7 @@ setup(
     long_description = "\n".join(doclines[2:]),
     license = "BSD",
     platforms = ["any"],
-    install_requires = requirements,
+    install_requires = ["future"],
     extras_require = {
         "arxml": ["lxml"],
         "kcd": ["lxml"],

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "fibex": ["lxml"],
         "xls": ["xlrd", "xlwt"],
         "xlsx": ["xlsxwriter"],
-        "yaml": ["pyaml"],
+        "yaml": ["pyyaml"],
         "dbc": [],
         "dbf": [],
         "json": [],


### PR DESCRIPTION
Reduce logging level for unsupported formats at import and signal error on load/dump instead. Some formats may not need to be supported if never used.
YAML format only depends on [PyYAML](https://pypi.python.org/pypi/PyYAML), not [pyaml](https://pypi.python.org/pypi/pyaml).
Always depend on future since it can be installed on Python 3 as well without any conflicts.