### PR TITLE
Hotfix dbc botschaft id none digit

### DIFF
--- a/canmatrix/dbc.py
+++ b/canmatrix/dbc.py
@@ -585,6 +585,8 @@ def load(f, **options):
                 botschaftId = temp.group(1)
                 signal = temp.group(2)
                 tempList = temp.group(3).split('"')
+                if not botschaftId.isdigit():
+                  continue
                 try:
                     for i in range(math.floor(len(tempList) / 2)):
                         bo = db.frameById(botschaftId)


### PR DESCRIPTION
Fix so that lines starting with _VAL and has no id are ignored