### PR TITLE
Fix dbf to kcd TypeError: object of type 'NoneType' has no len()

### DIFF
--- a/canmatrix/kcd.py
+++ b/canmatrix/kcd.py
@@ -102,7 +102,7 @@ def createSignal(signal, nodeList, typeEnums):
 
     consumer = etree.Element('Consumer')
     for receiver in signal.receiver:
-        if len(receiver) > 1 and receiver in nodeList:
+        if receiver in nodeList and len(receiver) > 1:
             noderef = etree.Element('NodeRef', id=str(nodeList[receiver]))
             consumer.append(noderef)
         if consumer.__len__() > 0:
@@ -181,7 +181,7 @@ def dump(dbs, f, **options):
             producer = etree.Element('Producer')
 
             for transmitter in frame.transmitter:
-                if len(transmitter) > 1 and transmitter in nodeList:
+                if transmitter in nodeList and len(transmitter) > 1:
                     noderef = etree.Element(
                         'NodeRef', id=str(
                             nodeList[transmitter]))

--- a/canmatrix/kcd.py
+++ b/canmatrix/kcd.py
@@ -157,11 +157,9 @@ def dump(dbs, f, **options):
         else:
             bus = etree.Element('Bus')
 
-#        if len(name) == 0:
-#            (path, ext) = os.path.splitext(filename)
-#            busName = path
-#        else:
-#            busName = name
+        if len(name) == 0:
+            (path, ext) = os.path.splitext(f.name)
+            name = path
 
         if len(name) > 0:
             bus.set("name", name)


### PR DESCRIPTION
There was an issue while converting dbf to kcd and no transmitter was present in nodeList.
While calculating the length of the transmitter an exception TypeError: object of type 'NoneType' has no len() was fired.
This commit fixes this bug by checking first if a transmitter or receiver is present in nodeList.