### PR TITLE
apply encoding in formats.loads function for Python 2

### DIFF
--- a/canmatrix/formats.py
+++ b/canmatrix/formats.py
@@ -47,6 +47,7 @@ def loads(string, importType=None, key="", flatImport=None, encoding="utf-8",**o
             string = bytes(string, encoding)
         fileObject = io.BytesIO(string)
     else:
+        string = string.encode(encoding)
         fileObject = StringIO.StringIO(string)
     return load(fileObject, importType, key, flatImport, **options)
 


### PR DESCRIPTION
fixes UnicodeDecodeErrorfor non-ascii strings