### PR TITLE
Use the default value if a frame attribute is None

### DIFF
--- a/canmatrix/canmatrix.py
+++ b/canmatrix/canmatrix.py
@@ -572,6 +572,8 @@ class Frame(object):
         for arg_name, destination, function, default in args:
             try:
                 value = kwargs[arg_name]
+                if value is None:
+                    value = default
             except KeyError:
                 value = default
             else:


### PR DESCRIPTION
Frame attributes are not verified to not to be None during initialization.
The issue was found when I tried to convert a dbf file into dbc format. The convert tool crashed in the following way:
```
msalau@msalau:~/canmatrix$ git log -1 --oneline
ce143d5 add doc to xlsx template (#165)
msalau@msalau:~/canmatrix$ python2 -m canmatrix.convert ./1.dbf ./1.dbc
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/msalau/canmatrix/canmatrix/convert.py", line 396, in <module>
    sys.exit(main())
  File "/home/msalau/canmatrix/canmatrix/convert.py", line 393, in main
    convert(infile, outfileName, **cmdlineOptions.__dict__)
  File "/home/msalau/canmatrix/canmatrix/convert.py", line 199, in convert
    canmatrix.formats.dumpp(outdbs, outfileName, **options)
  File "canmatrix/formats.py", line 113, in dumpp
    dump(db, fileObject, exportType, **options)
  File "canmatrix/formats.py", line 89, in dump
    moduleInstance.dump(canMatrixOrCluster, fileObject, **options)
  File "canmatrix/dbc.py", line 177, in dump
    if frame.transmitter.__len__() == 0:
AttributeError: 'NoneType' object has no attribute '__len__'
msalau@msalau:~/canmatrix$
```

I've tracked down the issue and discovered that the transmitter attribute is initialized with None on line 218 of dbf.py. The value then caused the crash during generation of the output file, since there is no `__len__` function associated.

The fix works for me.

Regards,
Maksim Salau.