### PR TITLE
Error on creation of dbc file with float variables

### DIFF
--- a/canmatrix/dbc.py
+++ b/canmatrix/dbc.py
@@ -366,9 +366,9 @@ def dump(db, f, **options):
                      ';\n').encode(dbcExportEncoding))
             if signal.is_float:
                 if int(signal.signalsize) > 32:
-                    f.write(('SIG_VALTYPE_ %d %s : 2;\n' % (frame.id, output_names[bo][signal])).encode(dbcExportEncoding))
+                    f.write(('SIG_VALTYPE_ %d %s : 2;\n' % (frame.id, output_names[frame][signal])).encode(dbcExportEncoding))
                 else:
-                    f.write(('SIG_VALTYPE_ %d %s : 1;\n' % (frame.id, output_names[bo][signal])).encode(dbcExportEncoding))
+                    f.write(('SIG_VALTYPE_ %d %s : 1;\n' % (frame.id, output_names[frame][signal])).encode(dbcExportEncoding))
  
     f.write("\n".encode(dbcExportEncoding))
 

--- a/canmatrix/sym.py
+++ b/canmatrix/sym.py
@@ -161,16 +161,18 @@ Title=\"canmatrix-Export\"
         # trigger all frames
         for frame in frames:
             name = "[" + frame.name + "]\n"
-
-            idType = "ID=%08Xh" % (frame.id)
+            if frame.extended == 1:
+                idType = "ID=%08Xh" % (frame.id)
+            else:
+                idType = "ID=%Xh" % (frame.id)
             if frame.comment is not None and len(frame.comment) > 0:
                 idType += "\t// " + \
                     frame.comment.replace('\n', ' ').replace('\r', ' ')
             idType += "\n"
             if frame.extended == 1:
                 idType += "Type=Extended\n"
-            else:
-                idType += "Type=Standard\n"
+          #  else:
+           #     idType += "Type=Standard\n"
 
             # check if frame has multiplexed signals
             multiplex = 0
@@ -185,7 +187,7 @@ Title=\"canmatrix-Export\"
                         muxSignal = signal
 
                 # ticker all possible mux-groups as i (0 - 2^ (number of bits of
-                # multiplexor))
+                # multiplexer))
                 first = 0
                 for i in range(0, 1 << int(muxSignal.signalsize)):
                     found = 0

--- a/canmatrix/sym.py
+++ b/canmatrix/sym.py
@@ -161,18 +161,19 @@ Title=\"canmatrix-Export\"
         # trigger all frames
         for frame in frames:
             name = "[" + frame.name + "]\n"
+
             if frame.extended == 1:
                 idType = "ID=%08Xh" % (frame.id)
             else:
-                idType = "ID=%Xh" % (frame.id)
+                idType = "ID=%03Xh" % (frame.id)
             if frame.comment is not None and len(frame.comment) > 0:
                 idType += "\t// " + \
                     frame.comment.replace('\n', ' ').replace('\r', ' ')
             idType += "\n"
             if frame.extended == 1:
                 idType += "Type=Extended\n"
-          #  else:
-           #     idType += "Type=Standard\n"
+            else:
+                idType += "Type=Standard\n"
 
             # check if frame has multiplexed signals
             multiplex = 0


### PR DESCRIPTION
Hi

If a signal of type float is defined, dbc.py (program lines 369 to 371)  raises an exception on creation of the an entry “SIG_VALTYPE_“ , probably because of wrong dictionary indexing.

Best regards
Geri
