### PR TITLE
Properly use 'decimal' in UTs

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -349,7 +349,7 @@ class Signal(object):
     def phys2raw(self, value=None):
         """Return the raw value (= as is on CAN).
 
-        :param decimal.Decimal or str value: (scaled) value or value choice to encode
+        :param value: (scaled) value compatible with `decimal` or value choice to encode
         :return: raw unscaled value as it appears on the bus
         :rtype: int or decimal.Decimal
         """
@@ -380,7 +380,7 @@ class Signal(object):
     def raw2phys(self, value, decodeToStr=False):
         """Decode the given raw value (= as is on CAN).
 
-        :param int or decimal.Decimal value: raw value. Don't use the type 'float' to remain accuracy.
+        :param value: raw value compatible with `decimal`.
         :param bool decodeToStr: If True, try to get value representation as *string* ('Init' etc.)
         :return: physical value (scaled)
         """

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -351,7 +351,7 @@ class Signal(object):
 
         :param decimal.Decimal or str value: (scaled) value or value choice to encode
         :return: raw unscaled value as it appears on the bus
-        :rtype: int or float
+        :rtype: int or decimal.Decimal
         """
         if value is None:
             return int(self.attributes.get('GenSigStartValue', 0))
@@ -374,13 +374,13 @@ class Signal(object):
         raw_value = (value - self.offset) / self.factor
 
         if not self.is_float:
-            raw_value = round(raw_value)
-        return float(raw_value)
+            raw_value = int(raw_value)
+        return raw_value
 
     def raw2phys(self, value, decodeToStr=False):
         """Decode the given raw value (= as is on CAN).
 
-        :param value: raw value. Preferably int or str, not float (to not lose precision)
+        :param int or decimal.Decimal value: raw value. Don't use the type 'float' to remain accuracy.
         :param bool decodeToStr: If True, try to get value representation as *string* ('Init' etc.)
         :return: physical value (scaled)
         """

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -349,7 +349,7 @@ class Signal(object):
     def phys2raw(self, value=None):
         """Return the raw value (= as is on CAN).
 
-        :param value: (scaled) value or value choice to encode
+        :param decimal.Decimal or str value: (scaled) value or value choice to encode
         :return: raw unscaled value as it appears on the bus
         :rtype: int or float
         """
@@ -366,8 +366,6 @@ class Signal(object):
                         "{} is invalid value choice for {}".format(value, self)
                 )
 
-        if not isinstance(value, defaultFloatFactory):  # use the same data type as offset and factor
-            value = defaultFloatFactory(value)
         if not (self.min <= value <= self.max):
             logger.info(
                 "Value {} is not valid for {}. Min={} and Max={}".format(
@@ -380,12 +378,13 @@ class Signal(object):
         return float(raw_value)
 
     def raw2phys(self, value, decodeToStr=False):
-        """Decode the given raw value (= as is on CAN)
-        :param value: raw value
+        """Decode the given raw value (= as is on CAN).
+
+        :param value: raw value. Preferably int or str, not float (to not lose precision)
         :param bool decodeToStr: If True, try to get value representation as *string* ('Init' etc.)
         :return: physical value (scaled)
         """
-        value = defaultFloatFactory(value)
+
         value = value * self.factor + self.offset
         if decodeToStr:
             for value_key, value_string in self.values.items():

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -351,6 +351,7 @@ class Signal(object):
 
         :param value: (scaled) value or value choice to encode
         :return: raw unscaled value as it appears on the bus
+        :rtype: int or float
         """
         if value is None:
             return int(self.attributes.get('GenSigStartValue', 0))
@@ -365,6 +366,8 @@ class Signal(object):
                         "{} is invalid value choice for {}".format(value, self)
                 )
 
+        if not isinstance(value, defaultFloatFactory):  # use the same data type as offset and factor
+            value = defaultFloatFactory(value)
         if not (self.min <= value <= self.max):
             logger.info(
                 "Value {} is not valid for {}. Min={} and Max={}".format(
@@ -373,8 +376,8 @@ class Signal(object):
         raw_value = (value - self.offset) / self.factor
 
         if not self.is_float:
-            raw_value = int(raw_value)
-        return raw_value
+            raw_value = round(raw_value)
+        return float(raw_value)
 
     def raw2phys(self, value, decodeToStr=False):
         """Decode the given raw value (= as is on CAN)
@@ -382,7 +385,7 @@ class Signal(object):
         :param bool decodeToStr: If True, try to get value representation as *string* ('Init' etc.)
         :return: physical value (scaled)
         """
-
+        value = defaultFloatFactory(value)
         value = value * self.factor + self.offset
         if decodeToStr:
             for value_key, value_string in self.values.items():

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -16,37 +16,37 @@ def test_signal_defaults_to_decimal():
 def test_encode_signal():
     s1 = canmatrix.canmatrix.Signal('signal', size=8)
     assert s1.phys2raw() == 0
-    assert s1.phys2raw(decimal.Decimal(1)) == 1
+    assert s1.phys2raw(1) == 1
     assert s1.phys2raw(s1.max) == 127
     assert s1.phys2raw(s1.min) == -128
 
     s2 = canmatrix.canmatrix.Signal('signal', size=10, is_signed=False)
     assert s2.phys2raw() == 0
-    assert s2.phys2raw(decimal.Decimal(10)) == 10
+    assert s2.phys2raw(10) == 10
     assert s2.phys2raw(s2.max) == 1023
     assert s2.phys2raw(s2.min) == 0
 
     s3 = canmatrix.canmatrix.Signal('signal', size=8, factor=2)
     assert s3.phys2raw() == 0
-    assert s3.phys2raw(decimal.Decimal(10)) == 5
+    assert s3.phys2raw(10) == 5
     assert s3.phys2raw(s3.max) == 127
     assert s3.phys2raw(s3.min) == -128
 
     s4 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor=5)
     assert s4.phys2raw() == 0
-    assert s4.phys2raw(decimal.Decimal(10)) == 2
+    assert s4.phys2raw(10) == 2
     assert s4.phys2raw(s4.max) == 255
     assert s4.phys2raw(s4.min) == 0
 
     s5 = canmatrix.canmatrix.Signal('signal', size=8, offset=2)
     assert s5.phys2raw() == 0
-    assert s5.phys2raw(decimal.Decimal(10)) == 8
+    assert s5.phys2raw(10) == 8
     assert s5.phys2raw(s5.max) == 127
     assert s5.phys2raw(s5.min) == -128
 
     s6 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, offset=5)
     assert s6.phys2raw() == 0
-    assert s6.phys2raw(decimal.Decimal(10)) == 5
+    assert s6.phys2raw(10) == 5
     assert s6.phys2raw(s6.max) == 255
     assert s6.phys2raw(s6.min) == 0
 
@@ -62,14 +62,14 @@ def test_encode_signal():
     assert s9.phys2raw() == 0
     assert s9.phys2raw(s9.max) == 65535
     assert s9.phys2raw(s9.min) == 0
-    assert s9.phys2raw(decimal.Decimal("50.123")) == 50123
+    assert s9.phys2raw(decimal.Decimal('50.123')) == 50123
 
     s10 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor='0.00005')
     assert s10.phys2raw() == 0
     assert s10.phys2raw(s10.max) == 255
     assert s10.phys2raw(s10.min) == 0
-    assert s10.phys2raw(decimal.Decimal("0.005")) == 100
-    assert s10.phys2raw(decimal.Decimal("0.003")) == 60
+    assert s10.phys2raw(decimal.Decimal('0.005')) == 100
+    assert s10.phys2raw(decimal.Decimal('0.003')) == 60
 
 
 def test_decode_signal():
@@ -106,7 +106,7 @@ def test_decode_signal():
     s7 = canmatrix.canmatrix.Signal('signal', size=16, is_signed=False, factor='0.001')
     assert s7.raw2phys(65535) == s7.max
     assert s7.raw2phys(0) == s7.min
-    assert s7.raw2phys(50123) == decimal.Decimal("50.123")
+    assert s7.raw2phys(50123) == decimal.Decimal('50.123')
 
     s8 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor='0.00005')
     assert s8.raw2phys(255) == s8.max

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -11,3 +11,47 @@ def test_signal_defaults_to_decimal():
 
     assert isinstance(signal.offset, decimal.Decimal)
     assert isinstance(signal.factor, decimal.Decimal)
+
+
+def test_decode_signal():
+    s1 = canmatrix.canmatrix.Signal('signal', size=8)
+    assert s1.raw2phys(1) == 1
+    assert s1.raw2phys(127) == s1.max
+    assert s1.raw2phys(-128) == s1.min
+
+    s2 = canmatrix.canmatrix.Signal('signal', size=10, is_signed=False)
+    assert s2.raw2phys(10) == 10
+    assert s2.raw2phys(s2.max) == 1023
+    assert s2.raw2phys(s2.min) == 0
+
+    s3 = canmatrix.canmatrix.Signal('signal', size=8, factor=2)
+    assert s3.raw2phys(5) == 10
+    assert s3.raw2phys(127) == s3.max
+    assert s3.raw2phys(-128) == s3.min
+
+    s4 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor=5)
+    assert s4.raw2phys(2) == 10
+    assert s4.raw2phys(255) == s4.max
+    assert s4.raw2phys(0) == s4.min
+
+    s5 = canmatrix.canmatrix.Signal('signal', size=8, offset=2)
+    assert s5.raw2phys(8) == 10
+    assert s5.raw2phys(127) == s5.max
+    assert s5.raw2phys(-128) == s5.min
+
+    s6 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, offset=5)
+    assert s6.raw2phys(5) == 10
+    assert s6.raw2phys(255) == s6.max
+    assert s6.raw2phys(0) == s6.min
+
+    s7 = canmatrix.canmatrix.Signal('signal', size=16, is_signed=False, factor='0.001')
+    assert s7.raw2phys(65535) == s7.max
+    assert s7.raw2phys(0) == s7.min
+    assert s7.raw2phys(50123) == decimal.Decimal("50.123")
+
+    s8 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor='0.00005')
+    assert s8.raw2phys(255) == s8.max
+    assert s8.raw2phys(0) == s8.min
+    assert s8.raw2phys(1) == decimal.Decimal('0.00005')
+    assert s8.raw2phys(2) == decimal.Decimal('0.0001')
+    assert s8.raw2phys(3) == decimal.Decimal('0.00015')

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -13,6 +13,65 @@ def test_signal_defaults_to_decimal():
     assert isinstance(signal.factor, decimal.Decimal)
 
 
+def test_encode_signal():
+    s1 = canmatrix.canmatrix.Signal('signal', size=8)
+    assert s1.phys2raw() == 0
+    assert s1.phys2raw(decimal.Decimal(1)) == 1
+    assert s1.phys2raw(s1.max) == 127
+    assert s1.phys2raw(s1.min) == -128
+
+    s2 = canmatrix.canmatrix.Signal('signal', size=10, is_signed=False)
+    assert s2.phys2raw() == 0
+    assert s2.phys2raw(decimal.Decimal(10)) == 10
+    assert s2.phys2raw(s2.max) == 1023
+    assert s2.phys2raw(s2.min) == 0
+
+    s3 = canmatrix.canmatrix.Signal('signal', size=8, factor=2)
+    assert s3.phys2raw() == 0
+    assert s3.phys2raw(decimal.Decimal(10)) == 5
+    assert s3.phys2raw(s3.max) == 127
+    assert s3.phys2raw(s3.min) == -128
+
+    s4 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor=5)
+    assert s4.phys2raw() == 0
+    assert s4.phys2raw(decimal.Decimal(10)) == 2
+    assert s4.phys2raw(s4.max) == 255
+    assert s4.phys2raw(s4.min) == 0
+
+    s5 = canmatrix.canmatrix.Signal('signal', size=8, offset=2)
+    assert s5.phys2raw() == 0
+    assert s5.phys2raw(decimal.Decimal(10)) == 8
+    assert s5.phys2raw(s5.max) == 127
+    assert s5.phys2raw(s5.min) == -128
+
+    s6 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, offset=5)
+    assert s6.phys2raw() == 0
+    assert s6.phys2raw(decimal.Decimal(10)) == 5
+    assert s6.phys2raw(s6.max) == 255
+    assert s6.phys2raw(s6.min) == 0
+
+    s7 = canmatrix.canmatrix.Signal('signal', size=8)
+    s7.addAttribute('GenSigStartValue', '5')
+    assert s7.phys2raw() == 5
+
+    s8 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, offset=5)
+    s8.addAttribute('GenSigStartValue', '5')
+    assert s8.phys2raw() == 5
+
+    s9 = canmatrix.canmatrix.Signal('signal', size=16, is_signed=False, factor='0.001')
+    assert s9.phys2raw() == 0
+    assert s9.phys2raw(s9.max) == 65535
+    assert s9.phys2raw(s9.min) == 0
+    assert s9.phys2raw(decimal.Decimal("50.123")) == 50123
+
+    s10 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, factor='0.00005')
+    assert s10.phys2raw() == 0
+    assert s10.phys2raw(s10.max) == 255
+    assert s10.phys2raw(s10.min) == 0
+    assert s10.phys2raw(decimal.Decimal("0.005")) == 100
+    assert s10.phys2raw(decimal.Decimal("0.003")) == 60
+
+
 def test_decode_signal():
     s1 = canmatrix.canmatrix.Signal('signal', size=8)
     assert s1.raw2phys(1) == 1

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -79,18 +79,18 @@ class TestCanmatrixCodec(unittest.TestCase):
         s8.addAttribute('GenSigStartValue', '5')
         self.assertEqual(s8.phys2raw(), 5)
 
-        s9 = Signal('signal', size=16, is_signed=False, factor=0.001)
+        s9 = Signal('signal', size=16, is_signed=False, factor='0.001')
         self.assertEqual(s9.phys2raw(), 0)
         self.assertEqual(s9.phys2raw(s9.max), 65535)
         self.assertEqual(s9.phys2raw(s9.min), 0)
-        self.assertEqual(s9.phys2raw(Decimal("50.123")), 50123)
+        self.assertEqual(s9.phys2raw(Decimal('50.123')), 50123)
 
-        s10 = Signal('signal', size=8, is_signed=False, factor=0.00005)
+        s10 = Signal('signal', size=8, is_signed=False, factor='0.00005')
         self.assertEqual(s10.phys2raw(), 0)
         self.assertEqual(s10.phys2raw(s10.max), 255)
         self.assertEqual(s10.phys2raw(s10.min), 0)
-        self.assertEqual(s10.phys2raw(Decimal("0.005")), 100)
-        self.assertEqual(s10.phys2raw(Decimal("0.003")), 60)
+        self.assertEqual(s10.phys2raw(Decimal('0.005')), 100)
+        self.assertEqual(s10.phys2raw(Decimal('0.003')), 60)
 
     # def test_encode_canmatrix(self):
     #     db_path = os.path.join(

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -5,7 +5,6 @@
 import unittest
 import tempfile
 import os
-from decimal import Decimal
 
 from canmatrix import formats
 from canmatrix.canmatrix import Signal
@@ -34,64 +33,6 @@ class TestCanmatrixCodec(unittest.TestCase):
         s4 = Signal('signal', size=8, is_little_endian=False)
         self.assertEqual(s4.bitstruct_format(), '>s8')
 
-    def test_encode_signal(self):
-        s1 = Signal('signal', size=8)
-        self.assertEqual(s1.phys2raw(), 0)
-        self.assertEqual(s1.phys2raw(1), 1)
-        self.assertEqual(s1.phys2raw(s1.max), 127)
-        self.assertEqual(s1.phys2raw(s1.min), -128)
-
-        s2 = Signal('signal', size=10, is_signed=False)
-        self.assertEqual(s2.phys2raw(), 0)
-        self.assertEqual(s2.phys2raw(10), 10)
-        self.assertEqual(s2.phys2raw(s2.max), 1023)
-        self.assertEqual(s2.phys2raw(s2.min), 0)
-
-        s3 = Signal('signal', size=8, factor=2)
-        self.assertEqual(s3.phys2raw(), 0)
-        self.assertEqual(s3.phys2raw(10), 5)
-        self.assertEqual(s3.phys2raw(s3.max), 127)
-        self.assertEqual(s3.phys2raw(s3.min), -128)
-
-        s4 = Signal('signal', size=8, is_signed=False, factor=5)
-        self.assertEqual(s4.phys2raw(), 0)
-        self.assertEqual(s4.phys2raw(10), 2)
-        self.assertEqual(s4.phys2raw(s4.max), 255)
-        self.assertEqual(s4.phys2raw(s4.min), 0)
-
-        s5 = Signal('signal', size=8, offset=2)
-        self.assertEqual(s5.phys2raw(), 0)
-        self.assertEqual(s5.phys2raw(10), 8)
-        self.assertEqual(s5.phys2raw(s5.max), 127)
-        self.assertEqual(s5.phys2raw(s5.min), -128)
-
-        s6 = Signal('signal', size=8, is_signed=False, offset=5)
-        self.assertEqual(s6.phys2raw(), 0)
-        self.assertEqual(s6.phys2raw(10), 5)
-        self.assertEqual(s6.phys2raw(s6.max), 255)
-        self.assertEqual(s6.phys2raw(s6.min), 0)
-
-        s7 = Signal('signal', size=8)
-        s7.addAttribute('GenSigStartValue', '5')
-        self.assertEqual(s7.phys2raw(), 5)
-
-        s8 = Signal('signal', size=8, is_signed=False, offset=5)
-        s8.addAttribute('GenSigStartValue', '5')
-        self.assertEqual(s8.phys2raw(), 5)
-
-        s9 = Signal('signal', size=16, is_signed=False, factor='0.001')
-        self.assertEqual(s9.phys2raw(), 0)
-        self.assertEqual(s9.phys2raw(s9.max), 65535)
-        self.assertEqual(s9.phys2raw(s9.min), 0)
-        self.assertEqual(s9.phys2raw(Decimal('50.123')), 50123)
-
-        s10 = Signal('signal', size=8, is_signed=False, factor='0.00005')
-        self.assertEqual(s10.phys2raw(), 0)
-        self.assertEqual(s10.phys2raw(s10.max), 255)
-        self.assertEqual(s10.phys2raw(s10.min), 0)
-        self.assertEqual(s10.phys2raw(Decimal('0.005')), 100)
-        self.assertEqual(s10.phys2raw(Decimal('0.003')), 60)
-
     def test_encode_canmatrix(self):
         db_path = os.path.join(
             os.path.dirname(__file__), "..", "test", "test.dbc")
@@ -103,49 +44,6 @@ class TestCanmatrixCodec(unittest.TestCase):
             }
             data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
             assert data_bytes == (0, 0x28, 0x04, 0, 0, 0, 0, 0)
-
-    def test_decode_signal(self):
-        s1 = Signal('signal', size=8)
-        self.assertEqual(s1.raw2phys(1), 1)
-        self.assertEqual(s1.raw2phys(127), s1.max)
-        self.assertEqual(s1.raw2phys(-128), s1.min)
-
-        s2 = Signal('signal', size=10, is_signed=False)
-        self.assertEqual(s2.raw2phys(10), 10)
-        self.assertEqual(s2.raw2phys(s2.max), 1023)
-        self.assertEqual(s2.raw2phys(s2.min), 0)
-
-        s3 = Signal('signal', size=8, factor=2)
-        self.assertEqual(s3.raw2phys(5), 10)
-        self.assertEqual(s3.raw2phys(127), s3.max)
-        self.assertEqual(s3.raw2phys(-128), s3.min)
-
-        s4 = Signal('signal', size=8, is_signed=False, factor=5)
-        self.assertEqual(s4.raw2phys(2), 10)
-        self.assertEqual(s4.raw2phys(255), s4.max)
-        self.assertEqual(s4.raw2phys(0), s4.min)
-
-        s5 = Signal('signal', size=8, offset=2)
-        self.assertEqual(s5.raw2phys(8), 10)
-        self.assertEqual(s5.raw2phys(127), s5.max)
-        self.assertEqual(s5.raw2phys(-128), s5.min)
-
-        s6 = Signal('signal', size=8, is_signed=False, offset=5)
-        self.assertEqual(s6.raw2phys(5), 10)
-        self.assertEqual(s6.raw2phys(255), s6.max)
-        self.assertEqual(s6.raw2phys(0), s6.min)
-
-        s7 = Signal('signal', size=16, is_signed=False, factor='0.001')
-        self.assertEqual(s7.raw2phys(65535), s7.max)
-        self.assertEqual(s7.raw2phys(0), s7.min)
-        self.assertEqual(s7.raw2phys(50123), Decimal("50.123"))
-
-        s8 = Signal('signal', size=8, is_signed=False, factor='0.00005')
-        self.assertEqual(s8.raw2phys(255), s8.max)
-        self.assertEqual(s8.raw2phys(0), s8.min)
-        self.assertEqual(s8.raw2phys(1), Decimal('0.00005'))
-        self.assertEqual(s8.raw2phys(2), Decimal('0.0001'))
-        self.assertEqual(s8.raw2phys(3), Decimal('0.00015'))
 
     def test_encode_decode_signal_value(self):
         db_path = os.path.join(

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -37,37 +37,37 @@ class TestCanmatrixCodec(unittest.TestCase):
     def test_encode_signal(self):
         s1 = Signal('signal', size=8)
         self.assertEqual(s1.phys2raw(), 0)
-        self.assertEqual(s1.phys2raw(Decimal(1)), 1)
+        self.assertEqual(s1.phys2raw(1), 1)
         self.assertEqual(s1.phys2raw(s1.max), 127)
         self.assertEqual(s1.phys2raw(s1.min), -128)
 
         s2 = Signal('signal', size=10, is_signed=False)
         self.assertEqual(s2.phys2raw(), 0)
-        self.assertEqual(s2.phys2raw(Decimal(10)), 10)
+        self.assertEqual(s2.phys2raw(10), 10)
         self.assertEqual(s2.phys2raw(s2.max), 1023)
         self.assertEqual(s2.phys2raw(s2.min), 0)
 
         s3 = Signal('signal', size=8, factor=2)
         self.assertEqual(s3.phys2raw(), 0)
-        self.assertEqual(s3.phys2raw(Decimal(10)), 5)
+        self.assertEqual(s3.phys2raw(10), 5)
         self.assertEqual(s3.phys2raw(s3.max), 127)
         self.assertEqual(s3.phys2raw(s3.min), -128)
 
         s4 = Signal('signal', size=8, is_signed=False, factor=5)
         self.assertEqual(s4.phys2raw(), 0)
-        self.assertEqual(s4.phys2raw(Decimal(10)), 2)
+        self.assertEqual(s4.phys2raw(10), 2)
         self.assertEqual(s4.phys2raw(s4.max), 255)
         self.assertEqual(s4.phys2raw(s4.min), 0)
 
         s5 = Signal('signal', size=8, offset=2)
         self.assertEqual(s5.phys2raw(), 0)
-        self.assertEqual(s5.phys2raw(Decimal(10)), 8)
+        self.assertEqual(s5.phys2raw(10), 8)
         self.assertEqual(s5.phys2raw(s5.max), 127)
         self.assertEqual(s5.phys2raw(s5.min), -128)
 
         s6 = Signal('signal', size=8, is_signed=False, offset=5)
         self.assertEqual(s6.phys2raw(), 0)
-        self.assertEqual(s6.phys2raw(Decimal(10)), 5)
+        self.assertEqual(s6.phys2raw(10), 5)
         self.assertEqual(s6.phys2raw(s6.max), 255)
         self.assertEqual(s6.phys2raw(s6.min), 0)
 
@@ -92,17 +92,17 @@ class TestCanmatrixCodec(unittest.TestCase):
         self.assertEqual(s10.phys2raw(Decimal('0.005')), 100)
         self.assertEqual(s10.phys2raw(Decimal('0.003')), 60)
 
-    # def test_encode_canmatrix(self):
-    #     db_path = os.path.join(
-    #         os.path.dirname(__file__), "..", "test", "test.dbc")
-    #     for matrix in formats.loadp(db_path).values():
-    #         test_frame1 = 0x123
-    #         data = {
-    #             'Signal': 2,
-    #             'someTestSignal': 101,
-    #         }
-    #         encoded = matrix.encode(test_frame1, data)
-    #         self.assertEqual(bytearray(encoded).hex(), bytearray((0, 0x28, 0x04, 0, 0, 0, 0, 0)).hex())
+    def test_encode_canmatrix(self):
+        db_path = os.path.join(
+            os.path.dirname(__file__), "..", "test", "test.dbc")
+        for bus in formats.loadp(db_path).values():
+            test_frame1 = 0x123
+            data = {
+                'Signal': 2,
+                'someTestSignal': 101,
+            }
+            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+            assert data_bytes == (0, 0x28, 0x04, 0, 0, 0, 0, 0)
 
     def test_decode_signal(self):
         s1 = Signal('signal', size=8)
@@ -147,53 +147,53 @@ class TestCanmatrixCodec(unittest.TestCase):
         self.assertEqual(s8.raw2phys(2), Decimal('0.0001'))
         self.assertEqual(s8.raw2phys(3), Decimal('0.00015'))
 
-    # def test_encode_decode_signal_value(self):
-    #     db_path = os.path.join(
-    #         os.path.dirname(__file__), "..", "test", "test.dbc")
-    #     for bus in formats.loadp(db_path).values():
-    #         test_frame1 = 0x123
-    #
-    #         data = {
-    #             'Signal': 2,
-    #             'someTestSignal': 101,
-    #         }
-    #         data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-    #         decoded = bus.decode(test_frame1, data_bytes, False)
-    #
-    #         for k, v in data.items():
-    #             assert decoded[k] == v
-    #
-    # def test_encode_decode_signal_value_choice_unicode(self):
-    #     db_path = os.path.join(
-    #         os.path.dirname(__file__), "..", "test", "test.dbc")
-    #     for bus in formats.loadp(db_path).values():
-    #         test_frame1 = 0x123
-    #
-    #         data = {
-    #             'Signal': u'two'
-    #         }
-    #         data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-    #
-    #         decoded = bus.decode(test_frame1, data_bytes, True)
-    #
-    #         for k, v in data.items():
-    #             assert str(decoded[k]) == v
-    #
-    # def test_encode_decode_signal_value_choice_str(self):
-    #     db_path = os.path.join(
-    #         os.path.dirname(__file__), "..", "test", "test.dbc")
-    #     for bus in formats.loadp(db_path).values():
-    #         test_frame1 = 0x123
-    #
-    #         data = {
-    #             'Signal': 'two'
-    #         }
-    #         data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-    #
-    #         decoded = bus.decode(test_frame1, data_bytes, True)
-    #
-    #         for k, v in data.items():
-    #             assert str(decoded[k]) == v
+    def test_encode_decode_signal_value(self):
+        db_path = os.path.join(
+            os.path.dirname(__file__), "..", "test", "test.dbc")
+        for bus in formats.loadp(db_path).values():
+            test_frame1 = 0x123
+
+            data = {
+                'Signal': 2,
+                'someTestSignal': 101,
+            }
+            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+            decoded = bus.decode(test_frame1, data_bytes, False)
+
+            for k, v in data.items():
+                assert decoded[k] == v
+
+    def test_encode_decode_signal_value_choice_unicode(self):
+        db_path = os.path.join(
+            os.path.dirname(__file__), "..", "test", "test.dbc")
+        for bus in formats.loadp(db_path).values():
+            test_frame1 = 0x123
+
+            data = {
+                'Signal': u'two'
+            }
+            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+
+            decoded = bus.decode(test_frame1, data_bytes, True)
+
+            for k, v in data.items():
+                assert str(decoded[k]) == v
+
+    def test_encode_decode_signal_value_choice_str(self):
+        db_path = os.path.join(
+            os.path.dirname(__file__), "..", "test", "test.dbc")
+        for bus in formats.loadp(db_path).values():
+            test_frame1 = 0x123
+
+            data = {
+                'Signal': 'two'
+            }
+            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+
+            decoded = bus.decode(test_frame1, data_bytes, True)
+
+            for k, v in data.items():
+                assert str(decoded[k]) == v
 
     def test_import_export_additional_frame_info(self):
         db_path = os.path.join(

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -5,12 +5,10 @@
 import unittest
 import tempfile
 import os
-import decimal
+from decimal import Decimal
 
 from canmatrix import formats
 from canmatrix.canmatrix import Signal
-
-D = decimal.Decimal
 
 
 class TestCanmatrixCodec(unittest.TestCase):
@@ -39,37 +37,37 @@ class TestCanmatrixCodec(unittest.TestCase):
     def test_encode_signal(self):
         s1 = Signal('signal', size=8)
         self.assertEqual(s1.phys2raw(), 0)
-        self.assertEqual(s1.phys2raw(1), 1)
+        self.assertEqual(s1.phys2raw(Decimal(1)), 1)
         self.assertEqual(s1.phys2raw(s1.max), 127)
         self.assertEqual(s1.phys2raw(s1.min), -128)
 
         s2 = Signal('signal', size=10, is_signed=False)
         self.assertEqual(s2.phys2raw(), 0)
-        self.assertEqual(s2.phys2raw(10), 10)
+        self.assertEqual(s2.phys2raw(Decimal(10)), 10)
         self.assertEqual(s2.phys2raw(s2.max), 1023)
         self.assertEqual(s2.phys2raw(s2.min), 0)
 
         s3 = Signal('signal', size=8, factor=2)
         self.assertEqual(s3.phys2raw(), 0)
-        self.assertEqual(s3.phys2raw(10), 5)
+        self.assertEqual(s3.phys2raw(Decimal(10)), 5)
         self.assertEqual(s3.phys2raw(s3.max), 127)
         self.assertEqual(s3.phys2raw(s3.min), -128)
 
         s4 = Signal('signal', size=8, is_signed=False, factor=5)
         self.assertEqual(s4.phys2raw(), 0)
-        self.assertEqual(s4.phys2raw(10), 2)
+        self.assertEqual(s4.phys2raw(Decimal(10)), 2)
         self.assertEqual(s4.phys2raw(s4.max), 255)
         self.assertEqual(s4.phys2raw(s4.min), 0)
 
         s5 = Signal('signal', size=8, offset=2)
         self.assertEqual(s5.phys2raw(), 0)
-        self.assertEqual(s5.phys2raw(10), 8)
+        self.assertEqual(s5.phys2raw(Decimal(10)), 8)
         self.assertEqual(s5.phys2raw(s5.max), 127)
         self.assertEqual(s5.phys2raw(s5.min), -128)
 
         s6 = Signal('signal', size=8, is_signed=False, offset=5)
         self.assertEqual(s6.phys2raw(), 0)
-        self.assertEqual(s6.phys2raw(10), 5)
+        self.assertEqual(s6.phys2raw(Decimal(10)), 5)
         self.assertEqual(s6.phys2raw(s6.max), 255)
         self.assertEqual(s6.phys2raw(s6.min), 0)
 
@@ -85,14 +83,14 @@ class TestCanmatrixCodec(unittest.TestCase):
         self.assertEqual(s9.phys2raw(), 0)
         self.assertEqual(s9.phys2raw(s9.max), 65535)
         self.assertEqual(s9.phys2raw(s9.min), 0)
-        self.assertEqual(s9.phys2raw(D(50123)*D(0.001)), 50123)
+        self.assertEqual(s9.phys2raw(Decimal("50.123")), 50123)
 
         s10 = Signal('signal', size=8, is_signed=False, factor=0.00005)
         self.assertEqual(s10.phys2raw(), 0)
         self.assertEqual(s10.phys2raw(s10.max), 255)
         self.assertEqual(s10.phys2raw(s10.min), 0)
-        self.assertEqual(s10.phys2raw(0.005), 100)
-        self.assertEqual(s10.phys2raw(0.003), 60)
+        self.assertEqual(s10.phys2raw(Decimal("0.005")), 100)
+        self.assertEqual(s10.phys2raw(Decimal("0.003")), 60)
 
     # def test_encode_canmatrix(self):
     #     db_path = os.path.join(
@@ -137,17 +135,17 @@ class TestCanmatrixCodec(unittest.TestCase):
         self.assertEqual(s6.raw2phys(255), s6.max)
         self.assertEqual(s6.raw2phys(0), s6.min)
 
-        s7 = Signal('signal', size=16, is_signed=False, factor=0.001)
+        s7 = Signal('signal', size=16, is_signed=False, factor='0.001')
         self.assertEqual(s7.raw2phys(65535), s7.max)
         self.assertEqual(s7.raw2phys(0), s7.min)
-        self.assertAlmostEqual(s7.raw2phys(50123), D(50.123))
+        self.assertEqual(s7.raw2phys(50123), Decimal("50.123"))
 
-        s8 = Signal('signal', size=8, is_signed=False, factor=0.00005)
+        s8 = Signal('signal', size=8, is_signed=False, factor='0.00005')
         self.assertEqual(s8.raw2phys(255), s8.max)
         self.assertEqual(s8.raw2phys(0), s8.min)
-        self.assertAlmostEqual(s8.raw2phys(1), D(0.00005))
-        self.assertAlmostEqual(s8.raw2phys(2), D(0.0001))
-        self.assertAlmostEqual(s8.raw2phys(3), D(0.00015))
+        self.assertEqual(s8.raw2phys(1), Decimal('0.00005'))
+        self.assertEqual(s8.raw2phys(2), Decimal('0.0001'))
+        self.assertEqual(s8.raw2phys(3), Decimal('0.00015'))
 
     # def test_encode_decode_signal_value(self):
     #     db_path = os.path.join(

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -5,9 +5,12 @@
 import unittest
 import tempfile
 import os
-from canmatrix import formats
+import decimal
 
+from canmatrix import formats
 from canmatrix.canmatrix import Signal
+
+D = decimal.Decimal
 
 
 class TestCanmatrixCodec(unittest.TestCase):
@@ -24,175 +27,175 @@ class TestCanmatrixCodec(unittest.TestCase):
         s1 = Signal('signal')
         self.assertEqual(s1.bitstruct_format(), '<s0')
 
-        s2 = Signal('signal', signalSize=8)
+        s2 = Signal('signal', size=8)
         self.assertEqual(s2.bitstruct_format(), '<s8')
 
-        s3 = Signal('signal', signalSize=8, is_signed=False)
+        s3 = Signal('signal', size=8, is_signed=False)
         self.assertEqual(s3.bitstruct_format(), '<u8')
 
-        s4 = Signal('signal', signalSize=8, is_little_endian=False)
+        s4 = Signal('signal', size=8, is_little_endian=False)
         self.assertEqual(s4.bitstruct_format(), '>s8')
 
     def test_encode_signal(self):
-        s1 = Signal('signal', signalSize=8)
+        s1 = Signal('signal', size=8)
         self.assertEqual(s1.phys2raw(), 0)
         self.assertEqual(s1.phys2raw(1), 1)
         self.assertEqual(s1.phys2raw(s1.max), 127)
         self.assertEqual(s1.phys2raw(s1.min), -128)
 
-        s2 = Signal('signal', signalSize=10, is_signed=False)
+        s2 = Signal('signal', size=10, is_signed=False)
         self.assertEqual(s2.phys2raw(), 0)
         self.assertEqual(s2.phys2raw(10), 10)
         self.assertEqual(s2.phys2raw(s2.max), 1023)
         self.assertEqual(s2.phys2raw(s2.min), 0)
 
-        s3 = Signal('signal', signalSize=8, factor=2)
+        s3 = Signal('signal', size=8, factor=2)
         self.assertEqual(s3.phys2raw(), 0)
         self.assertEqual(s3.phys2raw(10), 5)
         self.assertEqual(s3.phys2raw(s3.max), 127)
         self.assertEqual(s3.phys2raw(s3.min), -128)
 
-        s4 = Signal('signal', signalSize=8, is_signed=False, factor=5)
+        s4 = Signal('signal', size=8, is_signed=False, factor=5)
         self.assertEqual(s4.phys2raw(), 0)
         self.assertEqual(s4.phys2raw(10), 2)
         self.assertEqual(s4.phys2raw(s4.max), 255)
         self.assertEqual(s4.phys2raw(s4.min), 0)
 
-        s5 = Signal('signal', signalSize=8, offset=2)
+        s5 = Signal('signal', size=8, offset=2)
         self.assertEqual(s5.phys2raw(), 0)
         self.assertEqual(s5.phys2raw(10), 8)
         self.assertEqual(s5.phys2raw(s5.max), 127)
         self.assertEqual(s5.phys2raw(s5.min), -128)
 
-        s6 = Signal('signal', signalSize=8, is_signed=False, offset=5)
+        s6 = Signal('signal', size=8, is_signed=False, offset=5)
         self.assertEqual(s6.phys2raw(), 0)
         self.assertEqual(s6.phys2raw(10), 5)
         self.assertEqual(s6.phys2raw(s6.max), 255)
         self.assertEqual(s6.phys2raw(s6.min), 0)
 
-        s7 = Signal('signal', signalSize=8)
+        s7 = Signal('signal', size=8)
         s7.addAttribute('GenSigStartValue', '5')
         self.assertEqual(s7.phys2raw(), 5)
 
-        s8 = Signal('signal', signalSize=8, is_signed=False, offset=5)
+        s8 = Signal('signal', size=8, is_signed=False, offset=5)
         s8.addAttribute('GenSigStartValue', '5')
         self.assertEqual(s8.phys2raw(), 5)
 
-        s9 = Signal('signal', signalSize=16, is_signed=False, factor=0.001)
+        s9 = Signal('signal', size=16, is_signed=False, factor=0.001)
         self.assertEqual(s9.phys2raw(), 0)
-        self.assertEqual(s9.phys2raw(s9.max), 65534)
+        self.assertEqual(s9.phys2raw(s9.max), 65535)
         self.assertEqual(s9.phys2raw(s9.min), 0)
-        self.assertEqual(s9.phys2raw(50.123), 50123)
+        self.assertEqual(s9.phys2raw(D(50123)*D(0.001)), 50123)
 
-        s10 = Signal('signal', signalSize=8, is_signed=False, factor=0.00005)
+        s10 = Signal('signal', size=8, is_signed=False, factor=0.00005)
         self.assertEqual(s10.phys2raw(), 0)
         self.assertEqual(s10.phys2raw(s10.max), 255)
         self.assertEqual(s10.phys2raw(s10.min), 0)
         self.assertEqual(s10.phys2raw(0.005), 100)
         self.assertEqual(s10.phys2raw(0.003), 60)
 
-    def test_encode_canmatrix(self):
-        db_path = os.path.join(
-            os.path.dirname(__file__), "..", "test", "test.dbc")
-        for bus in formats.loadp(db_path).values():
-            test_frame1 = 0x123
-            data = {
-                'Signal': 2,
-                'someTestSignal': 101,
-            }
-            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-            assert data_bytes == (0, 0x28, 0x04, 0, 0, 0, 0, 0)
+    # def test_encode_canmatrix(self):
+    #     db_path = os.path.join(
+    #         os.path.dirname(__file__), "..", "test", "test.dbc")
+    #     for matrix in formats.loadp(db_path).values():
+    #         test_frame1 = 0x123
+    #         data = {
+    #             'Signal': 2,
+    #             'someTestSignal': 101,
+    #         }
+    #         encoded = matrix.encode(test_frame1, data)
+    #         self.assertEqual(bytearray(encoded).hex(), bytearray((0, 0x28, 0x04, 0, 0, 0, 0, 0)).hex())
 
     def test_decode_signal(self):
-        s1 = Signal('signal', signalSize=8)
+        s1 = Signal('signal', size=8)
         self.assertEqual(s1.raw2phys(1), 1)
         self.assertEqual(s1.raw2phys(127), s1.max)
         self.assertEqual(s1.raw2phys(-128), s1.min)
 
-        s2 = Signal('signal', signalSize=10, is_signed=False)
+        s2 = Signal('signal', size=10, is_signed=False)
         self.assertEqual(s2.raw2phys(10), 10)
         self.assertEqual(s2.raw2phys(s2.max), 1023)
         self.assertEqual(s2.raw2phys(s2.min), 0)
 
-        s3 = Signal('signal', signalSize=8, factor=2)
+        s3 = Signal('signal', size=8, factor=2)
         self.assertEqual(s3.raw2phys(5), 10)
         self.assertEqual(s3.raw2phys(127), s3.max)
         self.assertEqual(s3.raw2phys(-128), s3.min)
 
-        s4 = Signal('signal', signalSize=8, is_signed=False, factor=5)
+        s4 = Signal('signal', size=8, is_signed=False, factor=5)
         self.assertEqual(s4.raw2phys(2), 10)
         self.assertEqual(s4.raw2phys(255), s4.max)
         self.assertEqual(s4.raw2phys(0), s4.min)
 
-        s5 = Signal('signal', signalSize=8, offset=2)
+        s5 = Signal('signal', size=8, offset=2)
         self.assertEqual(s5.raw2phys(8), 10)
         self.assertEqual(s5.raw2phys(127), s5.max)
         self.assertEqual(s5.raw2phys(-128), s5.min)
 
-        s6 = Signal('signal', signalSize=8, is_signed=False, offset=5)
+        s6 = Signal('signal', size=8, is_signed=False, offset=5)
         self.assertEqual(s6.raw2phys(5), 10)
         self.assertEqual(s6.raw2phys(255), s6.max)
         self.assertEqual(s6.raw2phys(0), s6.min)
 
-        s7 = Signal('signal', signalSize=16, is_signed=False, factor=0.001)
+        s7 = Signal('signal', size=16, is_signed=False, factor=0.001)
         self.assertEqual(s7.raw2phys(65535), s7.max)
         self.assertEqual(s7.raw2phys(0), s7.min)
-        self.assertEqual(s7.raw2phys(50123), 50.123)
+        self.assertAlmostEqual(s7.raw2phys(50123), D(50.123))
 
-        s8 = Signal('signal', signalSize=8, is_signed=False, factor=0.00005)
+        s8 = Signal('signal', size=8, is_signed=False, factor=0.00005)
         self.assertEqual(s8.raw2phys(255), s8.max)
         self.assertEqual(s8.raw2phys(0), s8.min)
-        self.assertEqual(s8.raw2phys(1), 5e-05)
-        self.assertEqual(s8.raw2phys(2), 0.0001)
-        self.assertAlmostEqual(s8.raw2phys(3), 0.00015)
+        self.assertAlmostEqual(s8.raw2phys(1), D(0.00005))
+        self.assertAlmostEqual(s8.raw2phys(2), D(0.0001))
+        self.assertAlmostEqual(s8.raw2phys(3), D(0.00015))
 
-    def test_encode_decode_signal_value(self):
-        db_path = os.path.join(
-            os.path.dirname(__file__), "..", "test", "test.dbc")
-        for bus in formats.loadp(db_path).values():
-            test_frame1 = 0x123
-
-            data = {
-                'Signal': 2,
-                'someTestSignal': 101,
-            }
-            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-            decoded = bus.decode(test_frame1, data_bytes, False)
-
-            for k, v in data.items():
-                assert decoded[k] == v
-
-    def test_encode_decode_signal_value_choice_unicode(self):
-        db_path = os.path.join(
-            os.path.dirname(__file__), "..", "test", "test.dbc")
-        for bus in formats.loadp(db_path).values():
-            test_frame1 = 0x123
-
-            data = {
-                'Signal': u'two'
-            }
-            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-
-            decoded = bus.decode(test_frame1, data_bytes, True)
-
-            for k, v in data.items():
-                assert str(decoded[k]) == v
-
-    def test_encode_decode_signal_value_choice_str(self):
-        db_path = os.path.join(
-            os.path.dirname(__file__), "..", "test", "test.dbc")
-        for bus in formats.loadp(db_path).values():
-            test_frame1 = 0x123
-
-            data = {
-                'Signal': 'two'
-            }
-            data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
-
-            decoded = bus.decode(test_frame1, data_bytes, True)
-
-            for k, v in data.items():
-                assert str(decoded[k]) == v
+    # def test_encode_decode_signal_value(self):
+    #     db_path = os.path.join(
+    #         os.path.dirname(__file__), "..", "test", "test.dbc")
+    #     for bus in formats.loadp(db_path).values():
+    #         test_frame1 = 0x123
+    #
+    #         data = {
+    #             'Signal': 2,
+    #             'someTestSignal': 101,
+    #         }
+    #         data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+    #         decoded = bus.decode(test_frame1, data_bytes, False)
+    #
+    #         for k, v in data.items():
+    #             assert decoded[k] == v
+    #
+    # def test_encode_decode_signal_value_choice_unicode(self):
+    #     db_path = os.path.join(
+    #         os.path.dirname(__file__), "..", "test", "test.dbc")
+    #     for bus in formats.loadp(db_path).values():
+    #         test_frame1 = 0x123
+    #
+    #         data = {
+    #             'Signal': u'two'
+    #         }
+    #         data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+    #
+    #         decoded = bus.decode(test_frame1, data_bytes, True)
+    #
+    #         for k, v in data.items():
+    #             assert str(decoded[k]) == v
+    #
+    # def test_encode_decode_signal_value_choice_str(self):
+    #     db_path = os.path.join(
+    #         os.path.dirname(__file__), "..", "test", "test.dbc")
+    #     for bus in formats.loadp(db_path).values():
+    #         test_frame1 = 0x123
+    #
+    #         data = {
+    #             'Signal': 'two'
+    #         }
+    #         data_bytes = tuple(bytearray(bus.encode(test_frame1, data)))
+    #
+    #         decoded = bus.decode(test_frame1, data_bytes, True)
+    #
+    #         for k, v in data.items():
+    #             assert str(decoded[k]) == v
 
     def test_import_export_additional_frame_info(self):
         db_path = os.path.join(
@@ -205,3 +208,7 @@ class TestCanmatrixCodec(unittest.TestCase):
             with open(out_file_name, "r") as file:
                 data = file.read()
             self.assertIn("UserFrameAttr", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When playing with (yes, old) tests I found out some problems when mixing `decimal.Decimal` with `floats` ~~in single arithmetic operation. Also the converting back to int must be `round`, because `int(4.99999)` equals to 4, what is (I believe, and the old UTs also) not the wanted result.~~

The invalid (failing) tests are commented out for now.

I'll copy/move the reasonable old test to new test folder once I get a bit familiar with the pytest.

Regards