### PR TITLE
[WIP] Fix frame encoding

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -175,7 +175,7 @@ class Signal(object):
             ret_multiplex = int(value)
             self.mux_val = int(value)
         else:  # is it valid for None too?
-            self.is_multiplexer = True
+            self.is_multiplexer = False
             ret_multiplex = value
         return ret_multiplex
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -870,7 +870,7 @@ class Frame(object):
                     signals = sorted(self.signals, key=lambda s: s.getStartbit())
                     signals_values = OrderedDict()
                     for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
-                        signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
+                        signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
                 muxVal = int(signals_values.values()[0])
             # find all signals with the identified multiplexer-value
             muxedSignals = []
@@ -886,7 +886,7 @@ class Frame(object):
         #decode
         signals_values = OrderedDict()
         for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
-            signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
+            signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
 
         return signals_values
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -871,7 +871,7 @@ class Frame(object):
                     signals_values = OrderedDict()
                     for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
                         signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
-                muxVal = int(signals_values.values()[0])
+                muxVal = int(list(signals_values.values())[0])
             # find all signals with the identified multiplexer-value
             muxedSignals = []
             for signal in self.signals:

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -842,7 +842,7 @@ class Frame(object):
         signal_value = []
         for signal in signals:
             signal_value.append(
-                signal.phys2raw(data.get(signal.name))
+                signal.phys2raw(defaultFloatFactory(data.get(signal.name)))
             )
 
         return bitstruct.pack(fmt, *signal_value)


### PR DESCRIPTION
Decimal is the default float-factory since e8fdd35a which means that float values cannot be
encoded because - operator for float and Decimal is incompatible in Signal.phys2raw().