### PR TITLE
Fix signal is_multiplexer being True by default

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -171,10 +171,11 @@ class Signal(object):
     def multiplexSetter(self, value):
         self.mux_val = None
         self.is_multiplexer = False
+        ret_multiplex = None
         if value is not None and value != 'Multiplexor':
             ret_multiplex = int(value)
             self.mux_val = int(value)
-        else:  # is it valid for None too?
+        elif value == 'Multiplexor':
             self.is_multiplexer = True
             ret_multiplex = value
         return ret_multiplex


### PR DESCRIPTION
The default should be False, otherwise the first signal is encoded twice and decoding fails. I would answer the question in the code `is it valid for None too?` with No.

The error was introduced probably by always applying the `multiplexSetter` in `__attrs_post_init__` in commit a8893523.