### PR TITLE
Fix frame decoding and encoding

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -835,7 +835,7 @@ class Frame(object):
         signal_value = []
         for signal in signals:
             signal_value.append(
-                signal.phys2raw(data.get(signal.name))
+                signal.phys2raw(defaultFloatFactory(data.get(signal.name)))
             )
 
         return bitstruct.pack(fmt, *signal_value)

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -835,7 +835,7 @@ class Frame(object):
         signal_value = []
         for signal in signals:
             signal_value.append(
-                signal.phys2raw(defaultFloatFactory(data.get(signal.name)))
+                signal.phys2raw(data.get(signal.name))
             )
 
         return bitstruct.pack(fmt, *signal_value)

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -859,7 +859,7 @@ class Frame(object):
                     signals = sorted(self.signals, key=lambda s: s.getStartbit())
                     signals_values = OrderedDict()
                     for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
-                        signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
+                        signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
                 muxVal = int(signals_values.values()[0])
             # find all signals with the identified multiplexer-value
             muxedSignals = []
@@ -875,7 +875,7 @@ class Frame(object):
         #decode
         signals_values = OrderedDict()
         for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
-            signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
+            signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
 
         return signals_values
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -380,6 +380,8 @@ class Signal(object):
         :return: physical value (scaled)
         """
 
+        if self.is_float:
+            value = self.float_factory(value)
         value = value * self.factor + self.offset
         if decodeToStr:
             for value_key, value_string in self.values.items():
@@ -859,7 +861,7 @@ class Frame(object):
                     signals = sorted(self.signals, key=lambda s: s.getStartbit())
                     signals_values = OrderedDict()
                     for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
-                        signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
+                        signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
                 muxVal = int(signals_values.values()[0])
             # find all signals with the identified multiplexer-value
             muxedSignals = []
@@ -875,7 +877,7 @@ class Frame(object):
         #decode
         signals_values = OrderedDict()
         for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
-            signals_values[signal.name] = signal.raw2phys(defaultFloatFactory(value), decodeToStr)
+            signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
 
         return signals_values
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -862,7 +862,7 @@ class Frame(object):
                     signals_values = OrderedDict()
                     for signal, value in zip(signals, bitstruct.unpack(fmt, data)):
                         signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
-                muxVal = int(signals_values.values()[0])
+                muxVal = int(list(signals_values.values())[0])
             # find all signals with the identified multiplexer-value
             muxedSignals = []
             for signal in self.signals:

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -1,6 +1,5 @@
 import pytest
 import decimal
-from collections import OrderedDict
 
 import canmatrix.canmatrix
 
@@ -203,7 +202,7 @@ def test_signalgroup_delete_nothing(the_group, some_signal):
 
 
 def test_encode_decode_frame():
-    input_data = OrderedDict([('signal', decimal.Decimal('3.5'))])
+    input_data = {'signal': decimal.Decimal('3.5')}
 
     s1 = canmatrix.canmatrix.Signal('signal', size=32, is_float=True)
     f1 = canmatrix.canmatrix.Frame('frame', id=1, size=4)

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -1,5 +1,6 @@
 import pytest
 import decimal
+from collections import OrderedDict
 
 import canmatrix.canmatrix
 
@@ -199,3 +200,16 @@ def test_signalgroup_delete_nothing(the_group, some_signal):
     the_group.addSignal(some_signal)
     the_group.delSignal(canmatrix.canmatrix.Signal())
     assert len(the_group.signals) == 1
+
+
+def test_encode_decode_frame():
+    input_data = OrderedDict([('signal', decimal.Decimal('3.5'))])
+
+    s1 = canmatrix.canmatrix.Signal('signal', size=32, is_float=True)
+    f1 = canmatrix.canmatrix.Frame('frame', id=1, size=4)
+    f1.addSignal(s1)
+
+    raw_bytes = f1.encode(input_data)
+    decoded_data = f1.decode(raw_bytes)
+
+    assert decoded_data == input_data


### PR DESCRIPTION
I added a test to `test_canmatrix.py` that fails with the following error when decoding a float signal:
```
python /home/user/src/canmatrix/src/canmatrix/tests/test_canmatrix.py
Traceback (most recent call last):
  File "/home/user/src/canmatrix/src/canmatrix/tests/test_canmatrix.py", line 133, in <module>
    test_encode_decode_frame()
  File "/home/user/src/canmatrix/src/canmatrix/tests/test_canmatrix.py", line 128, in test_frame_encode_decode
    decoded_data = f1.decode(raw_bytes)
  File "/home/user/src/canmatrix/src/canmatrix/canmatrix.py", line 890, in decode
    signals_values[signal.name] = signal.raw2phys(value, decodeToStr)
  File "/home/user/src/canmatrix/src/canmatrix/canmatrix.py", line 389, in raw2phys
    value = value * self.factor + self.offset
TypeError: unsupported operand type(s) for *: 'float' and 'decimal.Decimal'
```

The second commit fixes this error by using the defaultFloatFactory when decoding raw values.

The third commit allows float values in the data which will be encoded. If it is a feature not to allow float values, feel free to not merge the last commit.
