### PR TITLE
Fix import of signed signals from DBF files

### DIFF
--- a/src/canmatrix/dbf.py
+++ b/src/canmatrix/dbf.py
@@ -353,7 +353,7 @@ def dump(mydb, f, **options):
                         startLittle=True) /
                     8) +
                 1)
-            sign = 'S'
+            sign = 'I'
 
             if not signal.is_signed:
                 sign = 'U'


### PR DESCRIPTION
BusMaster uses 'I' to denote signed signals, but not 'S'.
Thus conversion from DBC to DBF format is broken, but in opposite direction works just fine.
The PR fixes issue #207 