### PR TITLE
Add CanId tests. 

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -1635,5 +1635,5 @@ class CanId(object):
         return self.destination, self.pgn, self.source
 
     def __str__(self):
-        return "DA:{da:#02X} PGN:{pgn:#04X} SA:{sa:#02X}".format(
+        return "DA:0x{da:02X} PGN:0x{pgn:04X} SA:0x{sa:02X}".format(
             da=self.destination, pgn=self.pgn, sa=self.source)

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -212,3 +212,17 @@ def test_encode_decode_frame():
     decoded_data = f1.decode(raw_bytes)
 
     assert decoded_data == input_data
+
+
+# CanId tests
+def test_canid_parse_values():
+    can_id = canmatrix.canmatrix.CanId(0x01ABCD02)
+    assert can_id.source == 0x02
+    assert can_id.destination == 0x01
+    assert can_id.pgn == 0xABCD
+    assert can_id.tuples() == (1, 0xABCD, 2)
+
+
+def test_canid_repr():
+    can_id = canmatrix.canmatrix.CanId(0x01ABCD02)
+    assert str(can_id) == "DA:0x01 PGN:0xABCD SA:0x02"


### PR DESCRIPTION
Add CanId tests and beautify str representation, it prints
```DA:0x01 PGN:0xABCD SA:0x02```
instead of
```DA:0X1 PGN:0XABCD SA:0X2```