### PR TITLE
Use module loggers.

### DIFF
--- a/src/canmatrix/__init__.py
+++ b/src/canmatrix/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+import logging
 
 import canmatrix._version
 __version__ = canmatrix._version.get_versions()['version']
@@ -10,3 +11,6 @@ import canmatrix.cancluster as cancluster
 import canmatrix.convert as convert
 import canmatrix.copy as copy
 from canmatrix.canmatrix import *
+
+# Set default logging handler to avoid "No handler found" warnings in python 2.
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/canmatrix/arxml.py
+++ b/src/canmatrix/arxml.py
@@ -30,7 +30,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import logging
-logger = logging.getLogger('root')
 
 from builtins import *
 from lxml import etree
@@ -38,6 +37,8 @@ from lxml import etree
 from .canmatrix import *
 
 import decimal
+
+logger = logging.getLogger(__name__)
 default_float_factory = decimal.Decimal
 
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -39,10 +39,7 @@ from collections import OrderedDict
 import logging
 import fnmatch
 import decimal
-defaultFloatFactory = decimal.Decimal
 
-
-logger = logging.getLogger('root')
 try:
     from itertools import zip_longest as zip_longest
 except ImportError:
@@ -53,6 +50,8 @@ import struct
 from past.builtins import basestring
 import copy
 
+logger = logging.getLogger(__name__)
+defaultFloatFactory = decimal.Decimal
 
 class ExceptionTemplate(Exception):
     def __call__(self, *args):

--- a/src/canmatrix/cmcsv.py
+++ b/src/canmatrix/cmcsv.py
@@ -30,7 +30,7 @@ import csv
 import logging
 from canmatrix.xls_common import *
 
-logger = logging.getLogger('root')
+logger = logging.getLogger(__name__)
 
 if (sys.version_info > (3, 0)):
     import codecs

--- a/src/canmatrix/compare.py
+++ b/src/canmatrix/compare.py
@@ -22,12 +22,12 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
-
+import logging
 
 from .log import setup_logger, set_log_level
-logger = setup_logger('root')
-import types
 import sys
+
+logger = logging.getLogger(__name__)
 
 
 class compareResult(object):
@@ -479,7 +479,7 @@ def dumpResult(res, depth=0):
 
 
 def main():
-
+    setup_logger()
     from optparse import OptionParser
 
     usage = """

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -25,13 +25,15 @@ from __future__ import absolute_import
 
 #from .log import setup_logger, set_log_level
 from canmatrix.log import setup_logger, set_log_level
-logger = setup_logger('root')
 import sys
 import os
+import logging
 sys.path.append('..')
 import canmatrix.formats
 import canmatrix.canmatrix as cm
 import canmatrix.copy as cmcp
+
+logger = logging.getLogger(__name__)
 
 
 def convert(infile, outfileName, **options):
@@ -201,6 +203,7 @@ def convert(infile, outfileName, **options):
 
 
 def main():
+    setup_logger()
     from optparse import OptionParser
 
     usage = """

--- a/src/canmatrix/copy.py
+++ b/src/canmatrix/copy.py
@@ -21,9 +21,13 @@
 # DAMAGE.
 
 from __future__ import absolute_import
+import logging
 
 from .canmatrix import *
 from copy import deepcopy
+
+logger = logging.getLogger(__name__)
+
 
 def copyBU(buId, sourceDb, targetDb):
     """

--- a/src/canmatrix/dbc.py
+++ b/src/canmatrix/dbc.py
@@ -30,13 +30,13 @@ import collections
 import logging
 import decimal
 
-logger = logging.getLogger('root')
-default_float_factory = decimal.Decimal
 
 from builtins import *
 from .canmatrix import *
 import re
 
+logger = logging.getLogger(__name__)
+default_float_factory = decimal.Decimal
 
 #dbcExportEncoding = 'iso-8859-1'
 # CP1253

--- a/src/canmatrix/dbf.py
+++ b/src/canmatrix/dbf.py
@@ -30,11 +30,12 @@ from __future__ import print_function
 from copy import deepcopy
 
 import logging
-logger = logging.getLogger('root')
 
 from .canmatrix import *
 import re
 import decimal
+
+logger = logging.getLogger(__name__)
 default_float_factory = decimal.Decimal
 
 

--- a/src/canmatrix/formats.py
+++ b/src/canmatrix/formats.py
@@ -2,7 +2,6 @@
 from importlib import import_module
 import sys
 import logging
-logger = logging.getLogger('root')
 import canmatrix
 import os
 if sys.version_info > (3, 0):
@@ -10,6 +9,7 @@ if sys.version_info > (3, 0):
 else:
     import StringIO
 
+logger = logging.getLogger(__name__)
 moduleList = ["arxml", "cmcsv", "dbc", "dbf", "cmjson",
               "kcd", "fibex", "sym", "xls", "xlsx", "yaml"]
 loadedFormats = []

--- a/src/canmatrix/log.py
+++ b/src/canmatrix/log.py
@@ -27,15 +27,18 @@ from __future__ import absolute_import
 import logging
 
 
-def setup_logger(name='canmatrix'):
-    """Setup the module logger for canmatrix module. Return logger instance for possible further setting."""
+def setup_logger():
+    """Setup the root logger. Return the logger instance for possible further setting and use.
+
+    To be used from CLI scripts only.
+    """
     formatter = logging.Formatter(
         fmt='%(levelname)s - %(module)s - %(message)s')
 
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
 
-    logger = logging.getLogger(name)
+    logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
     return logger

--- a/src/canmatrix/log.py
+++ b/src/canmatrix/log.py
@@ -27,8 +27,8 @@ from __future__ import absolute_import
 import logging
 
 
-def setup_logger(name):
-    """Setup a project wide logger singleton"""
+def setup_logger(name='canmatrix'):
+    """Setup the module logger for canmatrix module. Return logger instance for possible further setting."""
     formatter = logging.Formatter(
         fmt='%(levelname)s - %(module)s - %(message)s')
 

--- a/src/canmatrix/sym.py
+++ b/src/canmatrix/sym.py
@@ -26,7 +26,6 @@ from __future__ import division
 from __future__ import absolute_import
 
 import logging
-logger = logging.getLogger('root')
 
 from builtins import *
 import collections
@@ -34,6 +33,8 @@ import shlex
 from .canmatrix import *
 import sys
 import decimal
+
+logger = logging.getLogger(__name__)
 default_float_factory = decimal.Decimal
 
 

--- a/src/canmatrix/xls.py
+++ b/src/canmatrix/xls.py
@@ -35,14 +35,11 @@ import xlwt
 import logging
 from canmatrix.xls_common import *
 import decimal
-default_float_factory = decimal.Decimal
-
-
-logger = logging.getLogger('root')
-
-
 from .canmatrix import *
 import xlrd
+
+logger = logging.getLogger(__name__)
+default_float_factory = decimal.Decimal
 
 
 # Font Size : 8pt * 20 = 160

--- a/src/canmatrix/xlsx.py
+++ b/src/canmatrix/xlsx.py
@@ -34,7 +34,7 @@ import os.path
 import xlsxwriter
 from canmatrix.xls_common import *
 
-
+logger = logging.getLogger(__name__)
 
 # Font Size : 8pt * 20 = 160
 #font = 'font: name Arial Narrow, height 160'

--- a/test/test.py
+++ b/test/test.py
@@ -21,7 +21,7 @@ if sys.version_info > (3, 2):
         sys.exit()
 
 from canmatrix.log import setup_logger, set_log_level
-logger = setup_logger('root')
+logger = setup_logger()
 set_log_level(logger, -1)
 
 export_types = []


### PR DESCRIPTION
As discussed in #237, use module loggers based on module names and only configure logger in main(). It is intended to replace+finish #164.

* every logger is child of main "canmatrix" logger
* if used as a standalone converter/comparator, the 'canmatrix' logger is configured to provide all messages
* if used as a library, the logger setting is up to the user. He can either configure its root logger or use default config by calling `canmatrix.log.setup_logger()`. Or leave default `logging` behavior.

If you agree with this change, it would be gentle to document the above points somewhere, but I don't know where.

The rows
```
if __name__ == '__main__':
    sys.exit(main())
```
in compare.py and convert.py don't work (at least due to import issues). It must be run using either examples/convert.py or the script generated by setuptool. I'll propose another PR to remove them, not to confuse anymore.