### PR TITLE
Fix test method name.

### DIFF
--- a/src/canmatrix/tests/test_frame_encoding.py
+++ b/src/canmatrix/tests/test_frame_encoding.py
@@ -12,7 +12,7 @@ def loadDbc():
     return canmatrix.formats.loadp(os.path.join(here ,"test_frame_decoding.dbc"), flatImport = True)
 
 
-def test_encode_with_dbc_little_endian():
+def test_encode_with_dbc_big_endian():
     cm = loadDbc()
     # 002#0C00057003CD1F83
     frame = cm.frameById(1)


### PR DESCRIPTION
I noticed incomplete coverage in 'test' directory due to duplicated test name. The 1st function was overriden by 2nd and did not run. Name fixed.