### PR TITLE
Tidy: attrs factory for list and dict

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -70,7 +70,7 @@ class BoardUnit(object):
 
     name = attr.ib(type=str)
     comment = attr.ib(default=None)
-    attributes = attr.ib(factory=dict, repr=False)
+    attributes = attr.ib(type=dict, factory=dict, repr=False)
 
     def attribute(self, attributeName, db=None, default=None):
         """Get Board unit attribute by its name.
@@ -140,11 +140,11 @@ class Signal(object):
     # offset = attr.ib(converter = float_factory, default = 0.0)
     calc_min_for_none = attr.ib(type=bool, default = True)
     calc_max_for_none = attr.ib(type=bool, default = True)
-    
+
     min  = attr.ib(
         converter=lambda value, float_factory=float_factory: (
-            float_factory(value) 
-            if value is not None 
+            float_factory(value)
+            if value is not None
             else value
         )
     )
@@ -154,8 +154,8 @@ class Signal(object):
 
     max =  attr.ib(
         converter=lambda value, float_factory=float_factory: (
-            float_factory(value) 
-            if value is not None 
+            float_factory(value)
+            if value is not None
             else value
         )
     )
@@ -164,16 +164,16 @@ class Signal(object):
         return  self.setMax()
 
     unit = attr.ib(type=str, default ="")
-    receiver = attr.ib(default = attr.Factory(list))
+    receiver = attr.ib(type=list, factory=list)
     comment = attr.ib(default = None)
     multiplex  = attr.ib(default = None)
 
     mux_value = attr.ib(default = None)
     is_float = attr.ib(type=bool, default=False)
     enumeration = attr.ib(type=str, default = None)
-    comments = attr.ib(type=dict, default = attr.Factory(dict))
-    attributes = attr.ib(type=dict, default = attr.Factory(dict))
-    values = attr.ib(type=dict, converter=normalizeValueTable, default = attr.Factory(dict))
+    comments = attr.ib(type=dict, factory=dict)
+    attributes = attr.ib(type=dict, factory=dict)
+    values = attr.ib(type=dict, converter=normalizeValueTable, factory=dict)
     muxValMax = attr.ib(default = 0)
     muxValMin = attr.ib(default = 0)
     muxerForSignal= attr.ib(type=str, default = None)
@@ -414,7 +414,7 @@ class SignalGroup(object):
     """
     name = attr.ib(type=str)
     id = attr.ib(type=int)
-    signals = attr.ib(factory=list, repr=False)
+    signals = attr.ib(type=list, factory=list, repr=False)
 
     def addSignal(self, signal):
         """Add a Signal to SignalGroup.
@@ -570,16 +570,16 @@ class Frame(object):
     name = attr.ib(default="")
     id = attr.ib(type=int, default = 0)
     size = attr.ib(default = 0)
-    transmitters = attr.ib(default = attr.Factory(list))
+    transmitters = attr.ib(type=list, factory=list)
     extended = attr.ib(type=bool, default = False)
     is_complex_multiplexed = attr.ib(type=bool, default = False)
     is_fd = attr.ib(type=bool, default = False)
     comment = attr.ib(default="")
-    signals = attr.ib(default = attr.Factory(list))
-    mux_names = attr.ib(type=dict, default = attr.Factory(dict))
-    attributes = attr.ib(type=dict, default = attr.Factory(dict))
-    receiver = attr.ib(default = attr.Factory(list))
-    signalGroups = attr.ib(default = attr.Factory(list))
+    signals = attr.ib(type=list, factory=list)
+    mux_names = attr.ib(type=dict, factory=dict)
+    attributes = attr.ib(type=dict, factory=dict)
+    receiver = attr.ib(type=list, factory=list)
+    signalGroups = attr.ib(type=list, factory=list)
 
     j1939_pgn = attr.ib(default = None)
     j1939_source = attr.ib(default = 0)
@@ -1148,18 +1148,18 @@ class CanMatrix(object):
     valueTables (global defined values)
     """
 
-    attributes = attr.ib(type=dict, default= attr.Factory(dict))
-    boardUnits = attr.ib(default = attr.Factory(list))
-    frames = attr.ib(default = attr.Factory(list))
+    attributes = attr.ib(type=dict, factory=dict)
+    boardUnits = attr.ib(type=list, factory=list)
+    frames = attr.ib(type=list, factory=list)
 
-    signalDefines = attr.ib(default = attr.Factory(dict))
-    frameDefines = attr.ib(default = attr.Factory(dict))
-    globalDefines = attr.ib(default = attr.Factory(dict))
-    buDefines = attr.ib(default = attr.Factory(dict))
-    valueTables = attr.ib(default = attr.Factory(dict))
-    envVars = attr.ib(default = attr.Factory(dict))
+    signalDefines = attr.ib(type=dict, factory=dict)
+    frameDefines = attr.ib(type=dict, factory=dict)
+    globalDefines = attr.ib(type=dict, factory=dict)
+    buDefines = attr.ib(type=dict, factory=dict)
+    valueTables = attr.ib(type=dict, factory=dict)
+    envVars = attr.ib(type=dict, factory=dict)
 
-    load_errors = attr.ib(factory=list)
+    load_errors = attr.ib(type=list, factory=list)
 
     def __iter__(self):
         """Matrix iterates over Frames (Messages)."""


### PR DESCRIPTION
Unify attr.ib(factory=...) instead of longer default=attr.Factory(list) so that the whole file uses only single approach. No functional change.

Plus 3 changes - trailing spaces removed by pycharm - I'm not able not to commit them.