### PR TITLE
Make classes upper case again

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -295,7 +295,7 @@ class Signal(object):
         if start_bit < 0:
             print("wrong start_bit found Signal: %s Startbit: %d" %
                   (self.name, start_bit))
-            raise StarbitLowerZero
+            raise StartbitLowerZero
         self.start_bit = start_bit
 
     def get_startbit(self, bit_numbering=None, start_little=None):
@@ -1526,11 +1526,11 @@ class CanMatrix(object):
         """Check all Frames and add unknown ECUs to the Matrix ECU list."""
         for frame in self.frames:
             for transmit_ecu in frame.transmitters:
-                self.add_ecu(canmatrix.ecu(transmit_ecu))
+                self.add_ecu(canmatrix.Ecu(transmit_ecu))
             frame.update_receiver()
             for signal in frame.signals:
                 for receive_ecu in signal.receivers:
-                    self.add_ecu(canmatrix.ecu(receive_ecu))
+                    self.add_ecu(canmatrix.Ecu(receive_ecu))
 
     def rename_frame(self, old, newName):
         """Rename Frame.

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -55,14 +55,14 @@ class ExceptionTemplate(Exception):
     def __call__(self, *args):
         return self.__class__(*(self.args + args))
 
-class StarbitLowerZero(ExceptionTemplate): pass
+class StartbitLowerZero(ExceptionTemplate): pass
 class EncodingComplexMultiplexed(ExceptionTemplate): pass
 class MissingMuxSignal(ExceptionTemplate): pass
 class DecodingComplexMultiplexed(ExceptionTemplate): pass
 class DecodingFrameLength(ExceptionTemplate): pass
 
 @attr.s
-class ecu(object):
+class Ecu(object):
     """
     Contains one Boardunit/ECU
     """
@@ -418,7 +418,7 @@ class Signal(object):
 
 
 @attr.s(cmp=False)
-class signal_group(object):
+class SignalGroup(object):
     """
     Represents signal-group, containing multiple Signals.
     """
@@ -467,7 +467,7 @@ class signal_group(object):
 
 
 @attr.s
-class decoded_signal(object):
+class DecodedSignal(object):
     """
     Contains a decoded signal (frame decoding)
 
@@ -691,7 +691,7 @@ class Frame(object):
         :param int Id: Group id
         :param list of str signalNames: list of Signal names to add. Non existing names are ignored.
         """
-        newGroup = signal_group(Name, Id)
+        newGroup = SignalGroup(Name, Id)
         self.signalGroups.append(newGroup)
         for signal in signalNames:
             signal = signal.strip()
@@ -706,7 +706,7 @@ class Frame(object):
 
         :param str name: group name
         :return: SignalGroup by name or None if not found.
-        :rtype: signal_group
+        :rtype: SignalGroup
         """
         for signalGroup in self.signalGroups:
             if signalGroup.name == name:
@@ -1010,7 +1010,7 @@ class Frame(object):
             returnDict= dict()
 
             for s, v in zip(self.signals, unpacked):
-                returnDict[s.name] = decoded_signal(v, s)
+                returnDict[s.name] = DecodedSignal(v, s)
 
             return returnDict
 
@@ -1372,7 +1372,7 @@ class CanMatrix(object):
         Returns Boardunit by Name.
 
         :param str name: BoardUnit name
-        :rtype: ecu or None
+        :rtype: Ecu or None
         """
         for test in self.ecus:
             if test.name == name:
@@ -1384,7 +1384,7 @@ class CanMatrix(object):
         Find ECUs by given glob pattern.
 
         :param globStr: glob pattern to filter BoardUnits. See `fnmatch.fnmatchcase`.
-        :rtype: list of ecu
+        :rtype: list of Ecu
         """
         returnArray = []
         for test in self.ecus:
@@ -1470,7 +1470,7 @@ class CanMatrix(object):
     def rename_ecu(self, old, newName):
         """Rename ECU in the Matrix. Update references in all Frames.
 
-        :param str or ecu old: old name or ECU instance
+        :param str or Ecu old: old name or ECU instance
         :param str newName: new name
         """
         if type(old).__name__ == 'instance':
@@ -1494,7 +1494,7 @@ class CanMatrix(object):
     def add_ecu(self, ecu):
         """Add new ECU to the Matrix. Do nothing if ecu with the same name already exists.
 
-        :param ecu ecu: ECU name to add
+        :param Ecu ecu: ECU name to add
         """
         for bu in self.ecus:
             if bu.name.strip() == ecu.name:
@@ -1504,7 +1504,7 @@ class CanMatrix(object):
     def del_ecu(self, ecu):
         """Remove ECU from Matrix and all Frames.
 
-        :param str or ecu ecu: ECU instance or glob pattern to remove from list
+        :param str or Ecu ecu: ECU instance or glob pattern to remove from list
         """
         if type(ecu).__name__ == 'instance':
             ecuList = [ecu]

--- a/src/canmatrix/dbc.py
+++ b/src/canmatrix/dbc.py
@@ -702,7 +702,7 @@ def load(f, **options):
                     myTempListe = temp.group(1).split(' ')
                     for ele in myTempListe:
                         if len(ele.strip()) > 1:
-                            db.ecus.append(canmatrix.ecu(ele))
+                            db.ecus.append(canmatrix.Ecu(ele))
 
             elif decoded.startswith("VAL_ "):
                 regexp = re.compile(r"^VAL_ +(\w+) +(\w+) +(.*);")

--- a/src/canmatrix/dbf.py
+++ b/src/canmatrix/dbf.py
@@ -231,7 +231,7 @@ def load(f, **options):
                 temstr = line.strip()[6:].strip()
                 boList = temstr.split(',')
                 for bo in boList:
-                    db.add_ecu(ecu(bo))
+                    db.add_ecu(Ecu(bo))
 
             if line.startswith("[START_SIGNALS]"):
                 temstr = line.strip()[15:].strip()

--- a/src/canmatrix/kcd.py
+++ b/src/canmatrix/kcd.py
@@ -351,7 +351,7 @@ def load(f, **options):
         db = canmatrix.CanMatrix()
         db.add_frame_defines("GenMsgCycleTime", 'INT 0 65535')
         for node in nodes:
-            db.BUs.add(canmatrix.ecu(node.get('name')))
+            db.BUs.add(canmatrix.Ecu(node.get('name')))
             nodelist[node.get('id')] = node.get('name')
 
         messages = bus.findall('./' + namespace + 'Message')

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -119,19 +119,19 @@ def test_decode_signal():
 
 # BoardUnit
 def test_ecu_find_attribute():
-    ecu = canmatrix.canmatrix.ecu(name="Gateway")
+    ecu = canmatrix.canmatrix.Ecu(name="Gateway")
     ecu.add_attribute("attr1", 255)
     assert ecu.attribute("attr1") == 255
 
 
 def test_ecu_no_attribute():
-    ecu = canmatrix.canmatrix.ecu(name="Gateway")
+    ecu = canmatrix.canmatrix.Ecu(name="Gateway")
     assert ecu.attribute("wrong") is None
     assert ecu.attribute("wrong", default=0) == 0
 
 
 def test_ecu_default_attr_from_db():
-    ecu = canmatrix.canmatrix.ecu(name="Gateway")
+    ecu = canmatrix.canmatrix.Ecu(name="Gateway")
     define = canmatrix.canmatrix.Define("INT 0 255")
     define.defaultValue = 33
     matrix = canmatrix.canmatrix.CanMatrix(ecu_defines={"temperature": define})
@@ -140,9 +140,9 @@ def test_ecu_default_attr_from_db():
 
 
 def test_ecu_repr():
-    ecu = canmatrix.canmatrix.ecu(name="Gateway")
+    ecu = canmatrix.canmatrix.Ecu(name="Gateway")
     ecu.add_comment("with bug")
-    assert str(ecu) == "ecu(name='Gateway', comment='with bug')"
+    assert str(ecu) == "Ecu(name='Gateway', comment='with bug')"
 
 
 # Signal (generic functions)
@@ -351,7 +351,7 @@ def test_signal_range_type_float():
 # SignalGroup
 @pytest.fixture
 def the_group():
-    return canmatrix.canmatrix.signal_group(name="TestGroup", id=1)
+    return canmatrix.canmatrix.SignalGroup(name="TestGroup", id=1)
 
 
 @pytest.fixture
@@ -695,11 +695,11 @@ def test_canid_repr():
 # DecodedSignal tests
 def test_decoded_signal_phys_value(some_signal):
     signal = canmatrix.canmatrix.Signal(factor="0.1", values={10: "Init"})
-    decoded = canmatrix.canmatrix.decoded_signal(100, signal)
+    decoded = canmatrix.canmatrix.DecodedSignal(100, signal)
     assert decoded.phys_value == decimal.Decimal("10")
 
 
 def test_decoded_signal_named_value():
     signal = canmatrix.canmatrix.Signal(factor="0.1", values={10: "Init"})
-    decoded = canmatrix.canmatrix.decoded_signal(100, signal)
+    decoded = canmatrix.canmatrix.DecodedSignal(100, signal)
     assert decoded.named_value == "Init"

--- a/src/canmatrix/xls.py
+++ b/src/canmatrix/xls.py
@@ -396,7 +396,7 @@ def load(file, **options):
 
     # BoardUnits:
     for x in range(index['BUstart'], index['BUend']):
-        db.add_ecu(canmatrix.ecu(sh.cell(0, x).value))
+        db.add_ecu(canmatrix.Ecu(sh.cell(0, x).value))
 
     # initialize:
     frameId = None

--- a/src/canmatrix/xlsx.py
+++ b/src/canmatrix/xlsx.py
@@ -434,7 +434,7 @@ def load(filename, **options):
         motorolaBitFormat = "msbreverse"
 
     sheet = readXlsx(filename, sheet=1, header=True)
-    db = canmarix.CanMatrix()
+    db = canmatrix.CanMatrix()
     letterIndex = []
     for a in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
         letterIndex.append(a)
@@ -467,7 +467,7 @@ def load(filename, **options):
 
     # BoardUnits:
     for x in range(_BUstart, _BUend):
-        db.add_ecu(canmatrix.ecu(sheet[0][letterIndex[x]]))
+        db.add_ecu(canmatrix.Ecu(sheet[0][letterIndex[x]]))
 
     # initialize:
     frameId = None

--- a/test/createTestFdMatrix.py
+++ b/test/createTestFdMatrix.py
@@ -11,8 +11,8 @@ import canmatrix
 
 db = canmatrix.CanMatrix()
 
-db.ecus.add(canmatrix.ecu("testBU"))
-db.ecus.add(canmatrix.ecu("recBU"))
+db.ecus.add(canmatrix.Ecu("testBU"))
+db.ecus.add(canmatrix.Ecu("recBU"))
 
 myFrame1 = canmatrix.Frame("canFdStandard1",Id=1,  dlc=24, is_fd = True, transmitter=["testBU"])
 myFrame2 = canmatrix.Frame("CanFdExtended2",Id=2,  dlc=16, extended = True, is_fd = True, transmitter=["testBU"])

--- a/test/createTestMatrix.py
+++ b/test/createTestMatrix.py
@@ -12,8 +12,8 @@ from canmatrix.canmatrix import *
 
 db = CanMatrix()
 
-db.ecus.add(ecu("testBU"))
-db.ecus.add(ecu("recBU"))
+db.ecus.add(Ecu("testBU"))
+db.ecus.add(Ecu("recBU"))
 
 myFrame = Frame("testFrame1", Id=0x123, dlc=8, transmitter="testBU")
 


### PR DESCRIPTION
When merging the 'typing' branch I realized that some classes was unwillingly refactored to snake case.