### PR TITLE
Resolve inspect issues in tests module (pep8)

### DIFF
--- a/src/canmatrix/tests/test_arxml.py
+++ b/src/canmatrix/tests/test_arxml.py
@@ -2,12 +2,12 @@
 import canmatrix.arxml
 import pathlib2
 
+
 def test_ecu_extract():
     here = pathlib2.Path(__file__).parent
     
     db = canmatrix.arxml.load(str(here / "MyECU.ecuc.arxml"))['']
-    assert db.frames != None
+    assert db.frames is not None
     assert len(db.frames) == 2
     assert len(db.frames[0].signals) == 3
     assert len(db.frames[1].signals) == 1
-        

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -328,24 +328,24 @@ def test_signal_max_specified_respects_calc_for_max_none_true():
 
 def test_signal_range_type_int():
     signal = canmatrix.Signal(is_float=False)
-    min, max = signal.calculate_raw_range()
+    signal_min, signal_max = signal.calculate_raw_range()
 
-    min_is = isinstance(min, int)
-    max_is = isinstance(max, int)
+    min_is = isinstance(signal_min, int)
+    max_is = isinstance(signal_max, int)
 
-    assert (min_is, max_is) == (True, True), str((type(min), type(max)))
+    assert (min_is, max_is) == (True, True), str((type(signal_min), type(signal_max)))
 
 
 def test_signal_range_type_float():
     signal = canmatrix.Signal(is_float=True)
-    min, max = signal.calculate_raw_range()
+    signal_min, signal_max = signal.calculate_raw_range()
 
     factory_type = type(signal.float_factory())
 
-    min_is = isinstance(min, factory_type)
-    max_is = isinstance(max, factory_type)
+    min_is = isinstance(signal_min, factory_type)
+    max_is = isinstance(signal_max, factory_type)
 
-    assert (min_is, max_is) == (True, True), str((type(min), type(max)))
+    assert (min_is, max_is) == (True, True), str((type(signal_min), type(signal_max)))
 
 
 # SignalGroup

--- a/src/canmatrix/tests/test_cmjson.py
+++ b/src/canmatrix/tests/test_cmjson.py
@@ -62,6 +62,7 @@ def test_export_long_signal_names():
 
     assert data['messages'][0]['signals'][0]['name'] == long_signal_name
 
+
 def test_export_min_max():
     matrix = canmatrix.canmatrix.CanMatrix()
     frame = canmatrix.canmatrix.Frame(name="test_frame", size=6, id=10)
@@ -71,11 +72,12 @@ def test_export_min_max():
     out_file = io.BytesIO()
     canmatrix.formats.dump(matrix, out_file, "cmjson", jsonAll=True)
     data = json.loads(out_file.getvalue().decode("utf-8"))
-    data['messages'][0]['signals'][0]['min'] == -5
-    data['messages'][0]['signals'][0]['max'] == 42
+    assert(data['messages'][0]['signals'][0]['min'] == '-5')
+    assert(data['messages'][0]['signals'][0]['max'] == '42')
+
 
 def test_import_min_max():
-    jsonInput = """{
+    json_input = """{
         "messages": [
             {
                 "attributes": {},
@@ -104,6 +106,6 @@ def test_import_min_max():
             }
         ]
     }"""
-    matrix = canmatrix.formats.loads(jsonInput, "cmjson", flatImport=True, jsonAll=True)
+    matrix = canmatrix.formats.loads(json_input, "cmjson", flatImport=True, jsonAll=True)
     assert matrix.frames[0].signals[0].min == -5
     assert matrix.frames[0].signals[0].max == 42

--- a/src/canmatrix/tests/test_copy.py
+++ b/src/canmatrix/tests/test_copy.py
@@ -1,6 +1,6 @@
-import pytest
 import canmatrix.canmatrix
 import canmatrix.copy
+
 
 def test_merge():
     matrix1 = canmatrix.canmatrix.CanMatrix()
@@ -12,19 +12,18 @@ def test_merge():
     frame2 = canmatrix.canmatrix.Frame("Frame2", id=2)
     matrix2.add_frame(frame2)
 
-
     matrix1.merge([matrix2])
     assert len(matrix1.frames) == 2
 
 
-def test_copy_ECU_with_frames():
+def test_copy_ecu_with_frames():
     matrix1 = canmatrix.canmatrix.CanMatrix()
     frame1 = canmatrix.canmatrix.Frame("Frame1", id=1)
     frame1.add_signal(canmatrix.canmatrix.Signal("SomeSignal"))
     matrix1.add_frame(frame1)
 
     matrix2 = canmatrix.canmatrix.CanMatrix()
-    frame2 = canmatrix.canmatrix.Frame("Frame2", id=2, transmitters= ["ECU"])
+    frame2 = canmatrix.canmatrix.Frame("Frame2", id=2, transmitters=["ECU"])
     matrix2.add_frame(frame2)
     matrix2.update_ecu_list()
 
@@ -33,14 +32,15 @@ def test_copy_ECU_with_frames():
     assert len(matrix1.frames) == 2
     assert len(matrix1.ecus) == 1
 
-def test_copy_ECU_without_frames():
+
+def test_copy_ecu_without_frames():
     matrix1 = canmatrix.canmatrix.CanMatrix()
     frame1 = canmatrix.canmatrix.Frame("Frame1", id=1)
     frame1.add_signal(canmatrix.canmatrix.Signal("SomeSignal"))
     matrix1.add_frame(frame1)
 
     matrix2 = canmatrix.canmatrix.CanMatrix()
-    frame2 = canmatrix.canmatrix.Frame("Frame2", id=2, transmitters= ["ECU"])
+    frame2 = canmatrix.canmatrix.Frame("Frame2", id=2, transmitters=["ECU"])
     matrix2.add_frame(frame2)
     matrix2.update_ecu_list()
     matrix2.add_ecu_defines("attrib", "STRING")

--- a/src/canmatrix/tests/test_dbc.py
+++ b/src/canmatrix/tests/test_dbc.py
@@ -32,13 +32,15 @@ def test_long_signal_name_imports():
         if line.strip().startswith("BA_ "):
             assert line.split()[5][1:-2] == long_signal_name
             long_name_found = True
-    assert long_name_found == True
-    assert name_found == True
+    assert long_name_found is True
+    assert name_found is True
+
 
 def test_create_define():
     defaults = {}
     test_string = canmatrix.dbc.create_define("my_data_type", canmatrix.Define('ENUM "A","B"'), "BA_", defaults)
     assert test_string == 'BA_DEF_ BA_ "my_data_type" ENUM "A","B";\n'
+
 
 def test_create_attribute_string():
     test_string = canmatrix.dbc.create_attribute_string("my_attribute", "BO_", "name", "value", True)
@@ -46,9 +48,11 @@ def test_create_attribute_string():
     test_string = canmatrix.dbc.create_attribute_string("my_attribute", "BO_", "name", 1.23, False)
     assert test_string == 'BA_ "my_attribute" BO_ name 1.23;\n'
 
+
 def test_create_comment_string():
-    test_string = canmatrix.dbc.create_comment_string("BO_","ident", "some comment","utf8","utf8")
+    test_string = canmatrix.dbc.create_comment_string("BO_", "ident", "some comment", "utf8", "utf8")
     assert test_string == b'CM_ BO_ ident "some comment";\n'
+
 
 def test_long_frame_name_imports():
     long_frame_name = u'A_VERY_LONG_FRAME_NAME_WHICH_SHOULD_BE_SPLIT_SOMEHOW'
@@ -74,8 +78,9 @@ def test_long_frame_name_imports():
         if line.strip().startswith("BA_ "):
             assert line.split()[4][1:-2] == long_frame_name
             long_name_found = True
-    assert long_name_found == True
-    assert name_found == True
+    assert long_name_found is True
+    assert name_found is True
+
 
 def test_long_ecu_name_imports():
     long_ecu_name = u'A_VERY_LONG_ECU_NAME_WHICH_SHOULD_BE_SPLIT_SOMEHOW'
@@ -102,8 +107,9 @@ def test_long_ecu_name_imports():
         if line.strip().startswith("BA_ "):
             assert line.split()[4][1:-2] == long_ecu_name
             long_name_found = True
-    assert long_name_found == True
-    assert name_found == True
+    assert long_name_found is True
+    assert name_found is True
+
 
 def test_long_envvar_name_imports():
     long_envvar_name = u'A_VERY_LONG_ENVIROMENT_NAME_WHICH_SHOULD_BE_SPLIT_SOMEHOW'
@@ -132,8 +138,9 @@ def test_long_envvar_name_imports():
         if line.strip().startswith("BA_ "):
             assert line.split()[3][1:-2] == long_envvar_name
             long_name_found = True
-    assert long_name_found == True
-    assert name_found == True
+    assert long_name_found is True
+    assert name_found is True
+
 
 def test_enum_with_comma():
     dbc = io.BytesIO(textwrap.dedent(u'''\
@@ -150,9 +157,10 @@ def test_enum_with_comma():
     ''').encode('utf-8'))
     matrix = canmatrix.dbc.load(dbc, dbcImportEncoding="utf8")
 
-    assert matrix.frame_defines[u'example1'].values == ["Val 1","",""," ","'","(",")","[","]","/","-","|","{","}",";",":","<",">",".","?","!","@","#","$","%","^","&","=","`","~"]
+    assert matrix.frame_defines[u'example1'].values == ["Val 1", "", ""] + list(" '()[]/-|{};:<>.?!@#$%^&=`~")
     assert matrix.signal_defines[u'example2'].values == ['Val1', ',']
     assert matrix.ecu_defines[u'example4'].values == ['Val1', ',']
+
 
 @pytest.mark.parametrize(
     'character',
@@ -161,13 +169,13 @@ def test_enum_with_comma():
         for c in string.punctuation
     ],
 )
-
 def test_enum_with_special_character(character):
     dbc = io.BytesIO(textwrap.dedent(u'''\
     BA_DEF_ BO_ "example1" ENUM "Val 1","{}";
     ''').format(character[0]).encode('utf-8'))
     matrix = canmatrix.dbc.load(dbc, dbcImportEncoding="utf8")
-    assert matrix.frame_defines[u'example1'].values == ["Val 1",character[0]]
+    assert matrix.frame_defines[u'example1'].values == ["Val 1", character[0]]
+
 
 def test_export_of_unknown_defines():
     db = canmatrix.CanMatrix()

--- a/src/canmatrix/tests/test_frame_decoding.py
+++ b/src/canmatrix/tests/test_frame_decoding.py
@@ -2,17 +2,19 @@ import pytest
 import canmatrix.formats
 import os.path
 
-def loadDbc():
+
+def load_dbc():
     here = os.path.dirname(os.path.realpath(__file__))
-    return canmatrix.formats.loadp(os.path.join(here ,"test_frame_decoding.dbc"), flatImport = True)
+    return canmatrix.formats.loadp(os.path.join(here, "test_frame_decoding.dbc"), flatImport=True)
+
 
 def test_decode_with_dbc_big_endian():
-    cm = loadDbc()
+    cm = load_dbc()
     # 001#8d00100100820100
-    frameData1 = bytearray([141, 0, 16, 1, 0, 130, 1, 0])
+    frame_data_1 = bytearray([141, 0, 16, 1, 0, 130, 1, 0])
 
     frame1 = cm.frame_by_id(1)
-    decoded1 = frame1.decode(frameData1)
+    decoded1 = frame1.decode(frame_data_1)
     assert decoded1["sig0"].raw_value == 1
     assert decoded1["sig1"].raw_value == 35
     assert decoded1["sig2"].raw_value == 0
@@ -25,12 +27,13 @@ def test_decode_with_dbc_big_endian():
     assert decoded1["sig9"].raw_value == 0
     assert decoded1["sig10"].raw_value == 0
 
+
 def test_decode_with_dbc_little_endian():
-    cm = loadDbc()
+    cm = load_dbc()
     # 002#0C00057003001F83
-    frameData = bytearray([12, 0, 5, 112, 3, 0, 31, 131])
+    frame_data = bytearray([12, 0, 5, 112, 3, 0, 31, 131])
     frame = cm.frame_by_id(2)
-    decoded = frame.decode(frameData)
+    decoded = frame.decode(frame_data)
     assert decoded["secSig1"].raw_value == 0
     assert decoded["secSig2"].raw_value == 0
     assert decoded["secSig3"].raw_value == 0
@@ -44,57 +47,53 @@ def test_decode_with_dbc_little_endian():
     assert decoded["secSig11"].raw_value == -144
     assert decoded["secSig12"].raw_value == 12
 
+
 def test_decode_with_too_little_dlc():
-    cm = loadDbc()
+    cm = load_dbc()
     # 002#0C00057003001F83
-    frameData = bytearray([12, 0, 5, 112, 3, 0, 31])
+    frame_data = bytearray([12, 0, 5, 112, 3, 0, 31])
     frame = cm.frame_by_id(2)
-    try:
-        decoded = frame.decode(frameData)
-    except canmatrix.DecodingFrameLength:
-        return True
-    assert False
+    with pytest.raises(canmatrix.DecodingFrameLength):
+        frame.decode(frame_data)
+
 
 def test_decode_with_too_big_dlc():
-    cm = loadDbc()
-    frameData1 = bytearray([0x38, 0x63, 0x8A, 0x7E, 0x00, 0x20, 0x00, 0x00])
+    cm = load_dbc()
+    frame_data1 = bytearray([0x38, 0x63, 0x8A, 0x7E, 0x00, 0x20, 0x00, 0x00])
     frame = cm.frame_by_id(4)
-    try:
-        decoded1 = frame.decode(frameData1)
-    except canmatrix.DecodingFrameLength:
-        return True
-    assert False
+    with pytest.raises(canmatrix.DecodingFrameLength):
+        frame.decode(frame_data1)
 
 
 def test_decode_with_dbc_float():
-    cm = loadDbc()
+    cm = load_dbc()
     # 003#38638A7E58A8C540
-    frameData = bytearray([0x38, 0x63, 0x8A, 0x7E, 0x58, 0xA8, 0xC5, 0x40])
+    frame_data = bytearray([0x38, 0x63, 0x8A, 0x7E, 0x58, 0xA8, 0xC5, 0x40])
     frame = cm.frame_by_id(3)
-    decoded = frame.decode(frameData)
+    decoded = frame.decode(frame_data)
     assert decoded["floatSignal1"].raw_value == 5.424999835668132e-05
-    assert decoded["floatSignal2"].raw_value ==  6.176799774169922
+    assert decoded["floatSignal2"].raw_value == 6.176799774169922
 
 
 def test_decode_with_dbc_multiplex():
-    cm = loadDbc()
-    frameData1 = bytearray([0x38, 0x63, 0x8A, 0x7E, 0x00, 0x20, 0x00])
+    cm = load_dbc()
+    frame_data1 = bytearray([0x38, 0x63, 0x8A, 0x7E, 0x00, 0x20, 0x00])
     frame = cm.frame_by_id(4)
-    decoded1 = frame.decode(frameData1)
+    decoded1 = frame.decode(frame_data1)
     assert decoded1["myMuxer"].raw_value == 0
-    assert decoded1["muxSig9"].raw_value ==  0x20
+    assert decoded1["muxSig9"].raw_value == 0x20
     assert decoded1["muxSig1"].raw_value == 0x38
     assert decoded1["muxSig2"].raw_value == 0x63
     assert decoded1["muxSig3"].raw_value == 0x8A
     assert decoded1["muxSig4"].raw_value == 0x3F
     assert decoded1["muxSig9"].raw_value == 0x20
 
-    frameData2 = bytearray([0x38, 0x63, 0x8A, 0x1E, 0x18, 0x20, 0x20])
-    decoded2 = frame.decode(frameData2)
+    frame_data2 = bytearray([0x38, 0x63, 0x8A, 0x1E, 0x18, 0x20, 0x20])
+    decoded2 = frame.decode(frame_data2)
     assert decoded2["myMuxer"].raw_value == 1
     assert decoded2["muxSig9"].raw_value == 0x20
-    assert decoded2["muxSig5"].raw_value ==  -6
-    assert decoded2["muxSig6"].raw_value ==  0x18
-    assert decoded2["muxSig7"].raw_value ==  0x0C
-    assert decoded2["muxSig8"].raw_value ==  -8
-    assert decoded2["muxSig9"].raw_value ==  0x20
+    assert decoded2["muxSig5"].raw_value == -6
+    assert decoded2["muxSig6"].raw_value == 0x18
+    assert decoded2["muxSig7"].raw_value == 0x0C
+    assert decoded2["muxSig8"].raw_value == -8
+    assert decoded2["muxSig9"].raw_value == 0x20

--- a/src/canmatrix/tests/test_frame_encoding.py
+++ b/src/canmatrix/tests/test_frame_encoding.py
@@ -3,96 +3,96 @@ import os.path
 import textwrap
 
 import attr
-import pytest
 import canmatrix.formats
 
 
-def loadDbc():
+def load_dbc():
     here = os.path.dirname(os.path.realpath(__file__))
-    return canmatrix.formats.loadp(os.path.join(here ,"test_frame_decoding.dbc"), flatImport = True)
+    return canmatrix.formats.loadp(os.path.join(here, "test_frame_decoding.dbc"), flatImport=True)
 
 
 def test_encode_with_dbc_big_endian():
-    cm = loadDbc()
+    cm = load_dbc()
     # 002#0C00057003CD1F83
     frame = cm.frame_by_id(1)
 
-    toEncode = dict()
+    to_encode = dict()
 
-    toEncode["sig0"] = 1
-    toEncode["sig1"] = 35
-    toEncode["sig2"] = 0
-    toEncode["sig3"] = 2048
-    toEncode["sig4"] = 256
-    toEncode["sig5"] = 1
-    toEncode["sig6"] = 0
-    toEncode["sig7"] = 520
-    toEncode["sig8"] = 0
-    toEncode["sig9"] = 0
-    toEncode["sig10"] = 0
+    to_encode["sig0"] = 1
+    to_encode["sig1"] = 35
+    to_encode["sig2"] = 0
+    to_encode["sig3"] = 2048
+    to_encode["sig4"] = 256
+    to_encode["sig5"] = 1
+    to_encode["sig6"] = 0
+    to_encode["sig7"] = 520
+    to_encode["sig8"] = 0
+    to_encode["sig9"] = 0
+    to_encode["sig10"] = 0
 
+    frame_data = frame.encode(to_encode)
+    assert frame_data == bytearray([141, 0, 16, 1, 0, 130, 1, 0])
 
-    frameData = frame.encode(toEncode)
-    assert frameData == bytearray([141, 0, 16, 1, 0, 130, 1, 0])
 
 def test_encode_with_dbc_little_endian():
-    cm = loadDbc()
+    cm = load_dbc()
     # 002#0C00057003CD1F83
     frame = cm.frame_by_id(2)
 
-    toEncode = dict()
-    toEncode["secSig1"] = 0
-    toEncode["secSig2"] = 0
-    toEncode["secSig3"] = 0
-    toEncode["secSig4"] = 2
-    toEncode["secSig5"] = 0
-    toEncode["secSig6"] = 0
-    toEncode["secSig7"] = 0
-    toEncode["secSig8"] = 3
-    toEncode["secSig9"] = 1
-    toEncode["secSig10"] = 1280
-    toEncode["secSig11"] = -144
-    toEncode["secSig12"] = 12
+    to_encode = dict()
+    to_encode["secSig1"] = 0
+    to_encode["secSig2"] = 0
+    to_encode["secSig3"] = 0
+    to_encode["secSig4"] = 2
+    to_encode["secSig5"] = 0
+    to_encode["secSig6"] = 0
+    to_encode["secSig7"] = 0
+    to_encode["secSig8"] = 3
+    to_encode["secSig9"] = 1
+    to_encode["secSig10"] = 1280
+    to_encode["secSig11"] = -144
+    to_encode["secSig12"] = 12
 
-    frameData = frame.encode(toEncode)
-    assert frameData == bytearray([0x0c, 0x00, 0x05, 0x70, 0x03, 0x00, 0x10, 0x83])
+    frame_data = frame.encode(to_encode)
+    assert frame_data == bytearray([0x0c, 0x00, 0x05, 0x70, 0x03, 0x00, 0x10, 0x83])
 
 
 def test_encode_with_dbc_float():
-    cm = loadDbc()
+    cm = load_dbc()
     # 003#38638A7E58A8C540
     frame = cm.frame_by_id(3)
 
-    toEncode = dict()
-    toEncode["floatSignal1"] = 5.424999835668132e-05
-    toEncode["floatSignal2"] =  6.176799774169922
-    frameData = frame.encode(toEncode)
-    assert frameData == bytearray([0x38, 0x63, 0x8A, 0x7E, 0x58, 0xA8, 0xC5, 0x40])
+    to_encode = dict()
+    to_encode["floatSignal1"] = 5.424999835668132e-05
+    to_encode["floatSignal2"] = 6.176799774169922
+    frame_data = frame.encode(to_encode)
+    assert frame_data == bytearray([0x38, 0x63, 0x8A, 0x7E, 0x58, 0xA8, 0xC5, 0x40])
+
 
 def test_encode_with_dbc_multiplex():
-    cm = loadDbc()
+    cm = load_dbc()
 
     frame = cm.frame_by_id(4)
-    toEncode1 = dict()
-    toEncode1["myMuxer"] = 0
-    toEncode1["muxSig9"] =  0x20
-    toEncode1["muxSig1"] = 0x38
-    toEncode1["muxSig2"] = 0x63
-    toEncode1["muxSig3"] = 0x8A
-    toEncode1["muxSig4"] = 0x3F
+    to_encode1 = dict()
+    to_encode1["myMuxer"] = 0
+    to_encode1["muxSig9"] = 0x20
+    to_encode1["muxSig1"] = 0x38
+    to_encode1["muxSig2"] = 0x63
+    to_encode1["muxSig3"] = 0x8A
+    to_encode1["muxSig4"] = 0x3F
 
-    frameData1 = frame.encode(toEncode1)
-    assert frameData1 == bytearray([0x38, 0x63, 0x8A, 0x7E, 0x00, 0x20, 0x00])
+    frame_data1 = frame.encode(to_encode1)
+    assert frame_data1 == bytearray([0x38, 0x63, 0x8A, 0x7E, 0x00, 0x20, 0x00])
 
-    toEncode2 = dict()
-    toEncode2["myMuxer"] = 1
-    toEncode2["muxSig9"] = 0x20
-    toEncode2["muxSig5"] =  -6
-    toEncode2["muxSig6"] =  0x18
-    toEncode2["muxSig7"] =  0x0C
-    toEncode2["muxSig8"] =  -8
-    frameData2 = frame.encode(toEncode2)
-    assert frameData2 == bytearray([0x38, 0x60, 0x80, 0x1E, 0x18, 0x20, 0x20])
+    to_encode2 = dict()
+    to_encode2["myMuxer"] = 1
+    to_encode2["muxSig9"] = 0x20
+    to_encode2["muxSig5"] = -6
+    to_encode2["muxSig6"] = 0x18
+    to_encode2["muxSig7"] = 0x0C
+    to_encode2["muxSig8"] = -8
+    frame_data2 = frame.encode(to_encode2)
+    assert frame_data2 == bytearray([0x38, 0x60, 0x80, 0x1E, 0x18, 0x20, 0x20])
 
 
 def test_sym():
@@ -149,8 +149,8 @@ def test_sym():
         eleven_bit_big_endian = attr.ib(default=0)
         eleven_bit_little_endian = attr.ib(default=0)
 
-        def encode(self, frame):
-            return frame.encode(attr.asdict(self))
+        def encode(self, frame_to_encode):
+            return frame_to_encode.encode(attr.asdict(self))
 
     unsigned_cases = {
         TestFrame(): b'\x00\x00\x00\x00\x00\x00\x00',

--- a/src/canmatrix/tests/test_utils.py
+++ b/src/canmatrix/tests/test_utils.py
@@ -1,5 +1,6 @@
 import canmatrix.utils
 
+
 def test_utils_guess_value():
     assert canmatrix.utils.guess_value("true") == "1"
     assert canmatrix.utils.guess_value("True") == "1"

--- a/src/canmatrix/tests/test_xls.py
+++ b/src/canmatrix/tests/test_xls.py
@@ -15,5 +15,5 @@ def test_parse_value_name_collumn():
     assert maxi == 15
     assert mini == 0
     assert offset == 0
-    assert value_table == {5 : "LabelX"}
+    assert value_table == {5: "LabelX"}
 


### PR DESCRIPTION
If you agree with refactorings based on [Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/) , I did some cleanup in `tests` module.  It is based on pyCharm code inspect.

Changes:
- Snake_case for variables
- Two blank lines surround top-level functions
- Not shadow variable/function names
- Spaces around `=`
- Boolean values compared by `is`, not `==`
- Use `pytest` module to assert that exceptions is raised
- Remove unused imports