### PR TITLE
Tidy and annotate 'convert' module. Make mypy happy.

### DIFF
--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 # Copyright (c) 2013, Eduard Broecker
 # All rights reserved.
@@ -20,111 +21,108 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
 
-#from .log import setup_logger, set_log_level
-from canmatrix.log import setup_logger, set_log_level
-import sys
-import os
 import logging
-sys.path.append('..')
-import canmatrix.formats
+import sys
+import typing
+
 import canmatrix.canmatrix as cm
 import canmatrix.copy
+import canmatrix.formats
+import canmatrix.log
 
 logger = logging.getLogger(__name__)
+sys.path.append('..')  # todo remove?
 
 
-def convert(infile, outfileName, **options):
-    dbs = {}
-
+def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> None
     logger.info("Importing " + infile + " ... ")
     dbs = canmatrix.formats.loadp(infile, **options)
     logger.info("done\n")
 
-    logger.info("Exporting " + outfileName + " ... ")
+    logger.info("Exporting " + out_file_name + " ... ")
 
-    outdbs = {}
+    out_dbs = {}
     for name in dbs:
         db = None
 
         if 'ecus' in options and options['ecus'] is not None:
-            ecuList = options['ecus'].split(',')
+            ecu_list = options['ecus'].split(',')
             db = cm.CanMatrix()
-            for ecu in ecuList:
+            for ecu in ecu_list:
                 canmatrix.copy.copy_ecu_with_frames(ecu, dbs[name], db)
         if 'frames' in options and options['frames'] is not None:
-            frameList = options['frames'].split(',')
+            frame_list = options['frames'].split(',')
             db = cm.CanMatrix()
-            for frame in frameList:
-                canmatrix.copy.copy_frame(frame, dbs[name], db)
+            for frame_name in frame_list:  # type: str
+                canmatrix.copy.copy_frame(frame_name, dbs[name], db)
         if options.get('signals', False):
             signal_list = options['signals'].split(',')
             db = cm.CanMatrix()
-            for signal in signal_list:
-                canmatrix.copy.copy_signal(signal, dbs[name], db)
-
+            for signal_name in signal_list:  # type: str
+                canmatrix.copy.copy_signal(signal_name, dbs[name], db)
 
         if db is None:
             db = dbs[name]
 
         if 'merge' in options and options['merge'] is not None:
-            mergeFiles = options['merge'].split(',')
-            for database in mergeFiles:
-                mergeString = database.split(':')
-                dbTempList = canmatrix.formats.loadp(mergeString[0])
-                for dbTemp in dbTempList:
-                    if mergeString.__len__() == 1:
-                        print ("merge complete: " + mergeString[0])
-                        db.merge([dbTempList[dbTemp]])
-#                        for frame in dbTempList[dbTemp].frames:
-#                            copyResult = canmatrix.copy.copy_frame(frame.id, dbTempList[dbTemp], db)
-#                            if copyResult == False:
-#                                logger.error("ID Conflict, could not copy/merge frame " + frame.name + "  %xh " % frame.id + database)
-                    for mergeOpt in mergeString[1:]:
+            merge_files = options['merge'].split(',')
+            for database in merge_files:
+                merge_string = database.split(':')
+                db_temp_list = canmatrix.formats.loadp(merge_string[0])
+                for dbTemp in db_temp_list:
+                    if merge_string.__len__() == 1:
+                        print("merge complete: " + merge_string[0])
+                        db.merge([db_temp_list[dbTemp]])
+                        # for frame in db_temp_list[dbTemp].frames:
+                        #    copyResult = canmatrix.copy.copy_frame(frame.id, db_temp_list[dbTemp], db)
+                        #    if copyResult == False:
+                        #        logger.error("ID Conflict, could not copy/merge frame " + frame.name + "  %xh " % frame.id + database)
+                    for mergeOpt in merge_string[1:]:
                         if mergeOpt.split('=')[0] == "ecu":
                             canmatrix.copy.copy_ecu_with_frames(
-                                mergeOpt.split('=')[1], dbTempList[dbTemp], db)
+                                mergeOpt.split('=')[1], db_temp_list[dbTemp], db)
                         if mergeOpt.split('=')[0] == "frame":
                             canmatrix.copy.copy_frame(
-                                mergeOpt.split('=')[1], dbTempList[dbTemp], db)
+                                mergeOpt.split('=')[1], db_temp_list[dbTemp], db)
 
         if 'renameEcu' in options and options['renameEcu'] is not None:
-            renameTuples = options['renameEcu'].split(',')
-            for renameTuple in renameTuples:
+            rename_tuples = options['renameEcu'].split(',')
+            for renameTuple in rename_tuples:
                 old, new = renameTuple.split(':')
                 db.rename_ecu(old, new)
         if 'deleteEcu' in options and options['deleteEcu'] is not None:
-            deleteEcuList = options['deleteEcu'].split(',')
-            for ecu in deleteEcuList:
+            delete_ecu_list = options['deleteEcu'].split(',')
+            for ecu in delete_ecu_list:
                 db.del_ecu(ecu)
         if 'renameFrame' in options and options['renameFrame'] is not None:
-            renameTuples = options['renameFrame'].split(',')
-            for renameTuple in renameTuples:
+            rename_tuples = options['renameFrame'].split(',')
+            for renameTuple in rename_tuples:
                 old, new = renameTuple.split(':')
                 db.rename_frame(old, new)
         if 'deleteFrame' in options and options['deleteFrame'] is not None:
-            deleteFrameList = options['deleteFrame'].split(',')
-            for frame in deleteFrameList:
-                db.del_frame(frame)
+            delete_frame_names = options['deleteFrame'].split(',')
+            for frame_name in delete_frame_names:
+                db.del_frame(frame_name)
         if 'addFrameReceiver' in options and options['addFrameReceiver'] is not None:
             touples = options['addFrameReceiver'].split(',')
             for touple in touples:
                 (frameName, ecu) = touple.split(':')
                 frames = db.glob_frames(frameName)
-                for frame in frames:
-                    for signal in frame.signals:
+                for frame in frames:  # type: canmatrix.Frame
+                    for signal in frame.signals:  # type: canmatrix.Signal
                         signal.add_receiver(ecu)
                     frame.update_receiver()
 
         if 'frameIdIncrement' in options and options['frameIdIncrement'] is not None:
-            idIncrement = int(options['frameIdIncrement'])
+            id_increment = int(options['frameIdIncrement'])
             for frame in db.frames:
-                frame.arbitration_id.id += idIncrement
+                frame.arbitration_id.id += id_increment
         if 'changeFrameId' in options and options['changeFrameId'] is not None:
-            changeTuples = options['changeFrameId'].split(',')
-            for renameTuple in changeTuples:
+            change_tuples = options['changeFrameId'].split(',')
+            for renameTuple in change_tuples:
                 old, new = renameTuple.split(':')
                 frame = db.frame_by_id(canmatrix.ArbitrationId(int(old)))
                 if frame is not None:
@@ -132,62 +130,61 @@ def convert(infile, outfileName, **options):
                 else:
                     logger.error("frame with id {} not found", old)
 
-
         if 'setFrameFd' in options and options['setFrameFd'] is not None:
-            fdFrameList = options['setFrameFd'].split(',')
-            for frame in fdFrameList:
-                framePtr = db.frame_by_name(frame)
-                if framePtr is not None:
-                    framePtr.is_fd = True
+            fd_frame_list = options['setFrameFd'].split(',')
+            for frame_name in fd_frame_list:
+                frame_ptr = db.frame_by_name(frame_name)
+                if frame_ptr is not None:
+                    frame_ptr.is_fd = True
         if 'unsetFrameFd' in options and options['unsetFrameFd'] is not None:
-            fdFrameList = options['unsetFrameFd'].split(',')
-            for frame in fdFrameList:
-                framePtr = db.frame_by_name(frame)
-                if framePtr is not None:
-                    framePtr.is_fd = False
+            fd_frame_list = options['unsetFrameFd'].split(',')
+            for frame_name in fd_frame_list:
+                frame_ptr = db.frame_by_name(frame_name)
+                if frame_ptr is not None:
+                    frame_ptr.is_fd = False
 
         if 'skipLongDlc' in options and options['skipLongDlc'] is not None:
-            deleteFrameList = []
+            delete_frame_list = []  # type: typing.List[canmatrix.Frame]
             for frame in db.frames:
                 if frame.size > int(options['skipLongDlc']):
-                    deleteFrameList.append(frame)
-            for frame in deleteFrameList:
+                    delete_frame_list.append(frame)
+            for frame in delete_frame_list:
                 db.del_frame(frame)
 
         if 'cutLongFrames' in options and options['cutLongFrames'] is not None:
             for frame in db.frames:
                 if frame.size > int(options['cutLongFrames']):
-                    deleteSignalList = []
+                    delete_signal_list = []
                     for sig in frame.signals:
-                        if sig.get_startbit() + int(sig.signalsize) > int(options['cutLongFrames'])*8:
-                            deleteSignalList.append(sig)
-                    for sig in deleteSignalList:
+                        if sig.get_startbit() + int(sig.size) > int(options['cutLongFrames'])*8:
+                            delete_signal_list.append(sig)
+                    for sig in delete_signal_list:
                         frame.signals.remove(sig)
                     frame.size = 0
                     frame.calc_dlc()
 
         if 'renameSignal' in options and options['renameSignal'] is not None:
-            renameTuples = options['renameSignal'].split(',')
-            for renameTuple in renameTuples:
+            rename_tuples = options['renameSignal'].split(',')
+            for renameTuple in rename_tuples:
                 old, new = renameTuple.split(':')
                 db.rename_signal(old, new)
         if 'deleteSignal' in options and options['deleteSignal'] is not None:
-            deleteSignalList = options['deleteSignal'].split(',')
-            for signal in deleteSignalList:
-                db.del_signal(signal)
+            delete_signal_names = options['deleteSignal'].split(',')
+            for signal_name in delete_signal_names:
+                db.del_signal(signal_name)
 
         if 'deleteZeroSignals' in options and options['deleteZeroSignals']:
             db.delete_zero_signals()
 
         if 'deleteSignalAttributes' in options and options[
                 'deleteSignalAttributes']:
-            unwantedAttributes = options['deleteSignalAttributes'].split(',')
-            db.del_signal_attributes(unwantedAttributes)
+            unwanted_attributes = options['deleteSignalAttributes'].split(',')
+            db.del_signal_attributes(unwanted_attributes)
 
         if 'deleteFrameAttributes' in options and options[
                 'deleteFrameAttributes']:
-            unwantedAttributes = options['deleteFrameAttributes'].split(',')
-            db.del_frame_attributes(unwantedAttributes)
+            unwanted_attributes = options['deleteFrameAttributes'].split(',')
+            db.del_frame_attributes(unwanted_attributes)
 
         if 'deleteObsoleteDefines' in options and options[
                 'deleteObsoleteDefines']:
@@ -199,18 +196,18 @@ def convert(infile, outfileName, **options):
         logger.info(name)
         logger.info("%d Frames found" % (db.frames.__len__()))
 
-        outdbs[name] = db
+        out_dbs[name] = db
 
     if 'force_output' in options and options['force_output'] is not None:
-        canmatrix.formats.dumpp(outdbs, outfileName, export_type=options[
+        canmatrix.formats.dumpp(out_dbs, out_file_name, exportType=options[
                                 'force_output'], **options)
     else:
-        canmatrix.formats.dumpp(outdbs, outfileName, **options)
+        canmatrix.formats.dumpp(out_dbs, out_file_name, **options)
     logger.info("done")
 
 
-def main():
-    setup_logger()
+def main():  # type: () -> int
+    canmatrix.log.setup_logger()
     from optparse import OptionParser
 
     usage = """
@@ -263,7 +260,7 @@ def main():
                       help="delete attributes from all frames\nExample --deleteFrameAttributes GenMsgCycle,CycleTime")
     parser.add_option("", "--deleteObsoleteDefines", action="store_true",
                       dest="deleteObsoleteDefines", default=False,
-                      help="delete defines from all Boardunits, frames and Signals\nExample --deleteObsoleteDefines")
+                      help="delete defines from all ECUs, frames and Signals\nExample --deleteObsoleteDefines")
     parser.add_option("", "--recalcDLC",
                       dest="recalcDLC", default=False,
                       help="recalculate dlc; max: use maximum of stored and calculated dlc; force: force new calculated dlc")
@@ -331,11 +328,11 @@ def main():
 
     parser.add_option("", "--additionalFrameAttributes",
                       dest="additionalFrameAttributes", default="",
-                      help="append collums to csv/xls(x), example: is_fd")
+                      help="append columns to csv/xls(x), example: is_fd")
 
     parser.add_option("", "--additionalSignalAttributes",
                       dest="additionalAttributes", default="",
-                      help="append collums to csv/xls(x), example: is_signed,attributes[\"GenSigStartValue\"] ")
+                      help="append columns to csv/xls(x), example: is_signed,attributes[\"GenSigStartValue\"] ")
 
     parser.add_option("", "--ecus",
                       dest="ecus", default=None,
@@ -398,19 +395,21 @@ def main():
     (cmdlineOptions, args) = parser.parse_args()
     if len(args) < 2:
         parser.print_help()
-        sys.exit(1)
+        return 1
 
     infile = args[0]
-    outfileName = args[1]
+    out_file_name = args[1]
 
     verbosity = cmdlineOptions.verbosity
     if cmdlineOptions.silent:
         # only print error messages, ignore verbosity flag
         verbosity = -1
 
-    set_log_level(logger, verbosity)
+    canmatrix.log.set_log_level(logger, verbosity)
 
-    convert(infile, outfileName, **cmdlineOptions.__dict__)
+    convert(infile, out_file_name, **cmdlineOptions.__dict__)
+    return 0
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
- code style cleanup
- add annotations
- resolve issues reported by mypy. As the scope of a variable is "longer" than we're used from C languages, we can't mix `for frame in [string, frame, names]` and `for frame in [Frame(), Frame()]` within single function. Because once is the variable type assigned to string, next assignment of type Frame is reported as an (static typing) problem. Therefore I renamed some variables to distinguish between string and "object". But this is only "cosmetical detail".