### PR TITLE
Mypy cleanup

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,21 @@
+# usage:
+# pythom -m pip intall mypy
+# python -m mypy ./src/canmatrix --config-file ./mypy.ini
+#
+# or configure "external tool" in pycharm:
+# program: $ModuleSdkPath$
+# arguments: -m mypy $FilePath$ --config-file $ProjectFileDir$\mypy.ini
+# working directory: C:\tmp (whatever outside the project to force mypy write absolute paths)
+# with "output filter": $FILE_PATH$:$LINE$:
+
 [mypy]
 show_column_numbers = True
 warn_unused_configs = True
 warn_unused_ignores = True
-
 check_untyped_defs = True
+
+# we want to delete this row later:
+strict_optional = False
 
 # ignore_missing_imports = True
 # allow_redefinition = True

--- a/src/canmatrix/cancluster.py
+++ b/src/canmatrix/cancluster.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import typing
+
 import canmatrix.canmatrix as cm
 
 

--- a/src/canmatrix/cancluster.py
+++ b/src/canmatrix/cancluster.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 import typing
-import canmatrix
+import canmatrix.canmatrix as canmatrix
 
 
 class CanCluster(dict):
 
     def __init__(self, *arg, **kw):
         super(CanCluster, self).__init__(*arg, **kw)
-        self._frames = []  # type: typing.MutableSequence[canmatrix.Frame]
-        self._signals = []
-        self._ecus = []
+        self._frames = []  # type: typing.List[canmatrix.Frame]
+        self._signals = []  # type: typing.List[canmatrix.Signal]
+        self._ecus = []  # type: typing.List[canmatrix.Ecu]
         self.update()
 
     def update_frames(self):  # type: () -> typing.MutableSequence[canmatrix.Frame]
-        frames = []  # type: typing.MutableSequence[canmatrix.Frame]
-        frame_names = []  # type: typing.MutableSequence[str]
+        frames = []  # type: typing.List[canmatrix.Frame]
+        frame_names = []  # type: typing.List[str]
         for matrixName in self:
             for frame in self[matrixName].frames:  # type: canmatrix.Frame
                 if frame.name not in frame_names:
@@ -30,8 +30,8 @@ class CanCluster(dict):
         return frames
 
     def update_signals(self):  # type: () -> typing.MutableSequence[canmatrix.Signal]
-        signals = []  # type: typing.MutableSequence[canmatrix.Signal]
-        signal_names = []  # type: typing.MutableSequence[str]
+        signals = []  # type: typing.List[canmatrix.Signal]
+        signal_names = []  # type: typing.List[str]
         for matrixName in self:
             for frame in self[matrixName].frames:
                 for signal in frame.signals:  # type: canmatrix.Signal
@@ -46,8 +46,8 @@ class CanCluster(dict):
         return signals
 
     def update_ecus(self):  # type: () -> typing.MutableSequence[canmatrix.Ecu]
-        ecus = []  # type: typing.MutableSequence[canmatrix.Ecu]
-        ecu_names = []  # type: typing.MutableSequence[str]
+        ecus = []  # type: typing.List[canmatrix.Ecu]
+        ecu_names = []  # type: typing.List[str]
         for matrixName in self:
             for ecu in self[matrixName].ecus:  # type: canmatrix.Ecu
                 if ecu.name not in ecu_names:

--- a/src/canmatrix/cancluster.py
+++ b/src/canmatrix/cancluster.py
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 import typing
-import canmatrix.canmatrix as canmatrix
+import canmatrix.canmatrix as cm
 
 
 class CanCluster(dict):
 
     def __init__(self, *arg, **kw):
         super(CanCluster, self).__init__(*arg, **kw)
-        self._frames = []  # type: typing.List[canmatrix.Frame]
-        self._signals = []  # type: typing.List[canmatrix.Signal]
-        self._ecus = []  # type: typing.List[canmatrix.Ecu]
+        self._frames = []  # type: typing.List[cm.Frame]
+        self._signals = []  # type: typing.List[cm.Signal]
+        self._ecus = []  # type: typing.List[cm.Ecu]
         self.update()
 
-    def update_frames(self):  # type: () -> typing.MutableSequence[canmatrix.Frame]
-        frames = []  # type: typing.List[canmatrix.Frame]
+    def update_frames(self):  # type: () -> typing.MutableSequence[cm.Frame]
+        frames = []  # type: typing.List[cm.Frame]
         frame_names = []  # type: typing.List[str]
         for matrixName in self:
-            for frame in self[matrixName].frames:  # type: canmatrix.Frame
+            for frame in self[matrixName].frames:  # type: cm.Frame
                 if frame.name not in frame_names:
                     frame_names.append(frame.name)
                     frames.append(frame)
@@ -29,12 +29,12 @@ class CanCluster(dict):
         self._frames = frames
         return frames
 
-    def update_signals(self):  # type: () -> typing.MutableSequence[canmatrix.Signal]
-        signals = []  # type: typing.List[canmatrix.Signal]
+    def update_signals(self):  # type: () -> typing.MutableSequence[cm.Signal]
+        signals = []  # type: typing.List[cm.Signal]
         signal_names = []  # type: typing.List[str]
         for matrixName in self:
             for frame in self[matrixName].frames:
-                for signal in frame.signals:  # type: canmatrix.Signal
+                for signal in frame.signals:  # type: cm.Signal
                     if signal.name not in signal_names:
                         signal_names.append(signal.name)
                         signals.append(signal)
@@ -45,11 +45,11 @@ class CanCluster(dict):
         self._signals = signals
         return signals
 
-    def update_ecus(self):  # type: () -> typing.MutableSequence[canmatrix.Ecu]
-        ecus = []  # type: typing.List[canmatrix.Ecu]
+    def update_ecus(self):  # type: () -> typing.MutableSequence[cm.Ecu]
+        ecus = []  # type: typing.List[cm.Ecu]
         ecu_names = []  # type: typing.List[str]
         for matrixName in self:
-            for ecu in self[matrixName].ecus:  # type: canmatrix.Ecu
+            for ecu in self[matrixName].ecus:  # type: cm.Ecu
                 if ecu.name not in ecu_names:
                     ecu_names.append(ecu.name)
                     ecus.append(ecu)
@@ -62,19 +62,19 @@ class CanCluster(dict):
         self.update_ecus()
 
     @property
-    def ecus(self):  # type: () -> typing.MutableSequence[canmatrix.Ecu]
+    def ecus(self):  # type: () -> typing.MutableSequence[cm.Ecu]
         if not self._ecus:
             self.update_ecus()
         return self._ecus
 
     @property
-    def frames(self):  # type: () -> typing.MutableSequence[canmatrix.Frame]
+    def frames(self):  # type: () -> typing.MutableSequence[cm.Frame]
         if not self._frames:
             self.update_frames()
         return self._frames
 
     @property
-    def signals(self):  # type: () -> typing.MutableSequence[canmatrix.Signal]
+    def signals(self):  # type: () -> typing.MutableSequence[cm.Signal]
         if not self._signals:
             self.update_signals()
         return self._signals

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -583,7 +583,7 @@ class ArbitrationId(object):
             raise ArbitrationIdOutOfRange('ID out of range')
 
     @classmethod
-    def from_compound_integer(cls, i):
+    def from_compound_integer(cls, i):  # type: (typing.Any) -> ArbitrationId
         return cls(
             id=i & cls.extended_id_mask,
             extended=(i & cls.compound_extended_mask) != 0,

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -28,31 +28,31 @@
 # TODO: Definitions should be disassembled
 
 from __future__ import division, absolute_import
-import math
-import attr
-if attr.__version__ < '17.4.0':
-    raise "need attrs >= 17.4.0"
 
-import logging
-import fnmatch
 import decimal
+import fnmatch
+import logging
+import math
+import struct
 import typing
+from itertools import chain
 
 try:
     from itertools import zip_longest as zip_longest
 except ImportError:
-    from itertools import izip_longest as zip_longest
+    from itertools import izip_longest as zip_longest  # type: ignore
 
-from itertools import chain
-import struct
+from past.builtins import basestring  # type: ignore
+import attr
 
-from past.builtins import basestring
 import canmatrix.copy
 import canmatrix.types
 import canmatrix.utils
 
+if attr.__version__ < '17.4.0':  # type: ignore
+    raise RuntimeError("need attrs >= 17.4.0")
 logger = logging.getLogger(__name__)
-defaultFloatFactory = decimal.Decimal
+defaultFloatFactory = decimal.Decimal  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
 
 class ExceptionTemplate(Exception):
     def __call__(self, *args):
@@ -65,35 +65,36 @@ class DecodingComplexMultiplexed(ExceptionTemplate): pass
 class DecodingFrameLength(ExceptionTemplate): pass
 class ArbitrationIdOutOfRange(ExceptionTemplate): pass
 
+
 @attr.s
 class Ecu(object):
     """
-    Contains one Boardunit/ECU
+    Represents one ECU.
     """
 
     name = attr.ib()  # type: str
     comment = attr.ib(default=None)  # type: typing.Optional[str]
     attributes = attr.ib(factory=dict, repr=False)  # type: typing.MutableMapping[str, typing.Any]
 
-    def attribute(self, attributeName, db=None, default=None):  # type: (str, CanMatrix, typing.Any) -> typing.Any
+    def attribute(self, attribute_name, db=None, default=None):  # type: (str, CanMatrix, typing.Any) -> typing.Any
         """Get Board unit attribute by its name.
 
-        :param str attributeName: attribute name.
+        :param str attribute_name: attribute name.
         :param CanMatrix db: Optional database parameter to get global default attribute value.
         :param default: Default value if attribute doesn't exist.
         :return: Return the attribute value if found, else `default` or None
         """
-        if attributeName in self.attributes:
-            return self.attributes[attributeName]
+        if attribute_name in self.attributes:
+            return self.attributes[attribute_name]
         elif db is not None:
-            if attributeName in db.ecu_defines:
-                define = db.ecu_defines[attributeName]
+            if attribute_name in db.ecu_defines:
+                define = db.ecu_defines[attribute_name]
                 return define.defaultValue
         return default
 
     def add_attribute(self, attribute, value):  # type (attribute: str, value: typing.Any) -> None
         """
-        Add the Attribute to current Boardunit/ECU. If the attribute already exists, update the value.
+        Add the Attribute to current ECU. If the attribute already exists, update the value.
 
         :param str attribute: Attribute name
         :param any value: Attribute value
@@ -106,7 +107,7 @@ class Ecu(object):
 
     def add_comment(self, comment):  # type: (str) -> None
         """
-        Set Board unit comment.
+        Set ECU comment.
 
         :param str comment: BU comment/description.
         """
@@ -129,25 +130,25 @@ class Signal(object):
     * is_little_endian (1: Intel, 0: Motorola)
     * is_signed (bool)
     * factor, offset, min, max
-    * receiver  (Boarunit/ECU-Name)
+    * receiver  (ECU Name)
     * attributes, _values, unit, comment
     * _multiplex ('Multiplexor' or Number of Multiplex)
     """
 
     name = attr.ib(default="")  # type: str
     # float_factory = attr.ib(default=defaultFloatFactory)
-    float_factory = defaultFloatFactory  # type: typing.Callable
+    float_factory = defaultFloatFactory  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
     start_bit = attr.ib(default=0)  # type: int
     size = attr.ib(default=0)  # type: int
     is_little_endian = attr.ib(default=True)  # type: bool
     is_signed = attr.ib(default=True)  # type: bool
-    offset = attr.ib(converter=float_factory, default=float_factory(0.0))  # type: decimal.Decimal
-    factor = attr.ib(converter=float_factory, default=float_factory(1.0))  # type: decimal.Decimal
+    offset = attr.ib(converter=float_factory, default=float_factory(0.0))  # type: canmatrix.types.PhysicalValue
+    factor = attr.ib(converter=float_factory, default=float_factory(1.0))  # type: canmatrix.types.PhysicalValue
 
     unit = attr.ib(default="")  # type: str
     receivers = attr.ib(factory=list)  # type: typing.MutableSequence[str]
     comment = attr.ib(default=None)  # type: typing.Optional[str]
-    multiplex = attr.ib(default=None)
+    multiplex = attr.ib(default=None)  # type: typing.Union[str, int]
 
     mux_value = attr.ib(default=None)
     is_float = attr.ib(default=False)  # type: bool
@@ -404,25 +405,23 @@ class Signal(object):
             raw_value = int(raw_value)
         return raw_value
 
-    def raw2phys(self, value, decodeToStr=False):
-        # type: (canmatrix.types.RawValue, bool) -> canmatrix.types.PhysicalValue
+    def raw2phys(self, value, decode_to_str=False):
+        # type: (canmatrix.types.RawValue, bool) -> typing.Union[canmatrix.types.PhysicalValue, str]
         """Decode the given raw value (= as is on CAN).
 
         :param value: raw value compatible with `decimal`.
-        :param bool decodeToStr: If True, try to get value representation as *string* ('Init' etc.)
+        :param bool decode_to_str: If True, try to get value representation as *string* ('Init' etc.)
         :return: physical value (scaled)
         """
-
         if self.is_float:
             value = self.float_factory(value)
-        value = value * self.factor + self.offset
-        if decodeToStr:
+        result = value * self.factor + self.offset  # type: typing.Union[canmatrix.types.PhysicalValue, str]
+        if decode_to_str:
             for value_key, value_string in self.values.items():
-                if value_key == value:
-                    value = value_string
+                if value_key == result:
+                    result = value_string
                     break
-
-        return value
+        return result
 
     def __str__(self):  # type: () -> str
         return self.name
@@ -504,7 +503,7 @@ class DecodedSignal(object):
         :return: value of Valuetable
         :rtype: typing.Union[str, int, decimal.Decimal]
         """
-        return self.signal.raw2phys(self.raw_value, decodeToStr=True)
+        return self.signal.raw2phys(self.raw_value, decode_to_str=True)
 
 
 # https://docs.python.org/3/library/itertools.html
@@ -630,6 +629,7 @@ class Frame(object):
     """
 
     name = attr.ib(default="")  # type: str
+    # mypy Unsupported converter:
     arbitration_id = attr.ib(converter=ArbitrationId.from_compound_integer, default=0)  # type: ArbitrationId
     size = attr.ib(default=0)  # type: int
     transmitters = attr.ib(factory=list)  # type: typing.MutableSequence[str]
@@ -691,7 +691,9 @@ class Frame(object):
 
     def recalc_J1939_id(self):  # type: () -> None
         """Recompute J1939 ID"""
-        self.arbitration_id.id = (self.j1939_source & 0xff) + ((self.j1939_pgn & 0xffff) << 8) + ((self.j1939_prio & 0x7) << 26)
+        self.arbitration_id.id = self.j1939_source & 0xff
+        self.arbitration_id.id += (self.j1939_pgn & 0xffff) << 8  # default pgn is None -> mypy reports error
+        self.arbitration_id.id += (self.j1939_prio & 0x7) << 26
         self.arbitration_id.extended = True
         self.is_j1939 = True
 
@@ -717,23 +719,21 @@ class Frame(object):
     #    self._sendType = value
     #    self.attributes["GenMsgCycleTime"] = value
 
-
-
-    def attribute(self, attributeName, db=None, default=None):
+    def attribute(self, attribute_name, db=None, default=None):
         # type: (str, typing.Optional[CanMatrix], typing.Any) -> typing.Any
         """Get any Frame attribute by its name.
 
-        :param str attributeName: attribute name, can be mandatory (ex: id) or optional (customer) attribute.
+        :param str attribute_name: attribute name, can be mandatory (ex: id) or optional (customer) attribute.
         :param CanMatrix db: Optional database parameter to get global default attribute value.
         :param default: Default value if attribute doesn't exist.
         :return: Return the attribute value if found, else `default` or None
         """
-        if attributeName in attr.fields_dict(type(self)):
-            return getattr(self, attributeName)
-        if attributeName in self.attributes:
-            return self.attributes[attributeName]
-        elif db is not None and attributeName in db.frame_defines:
-            define = db.frame_defines[attributeName]
+        if attribute_name in attr.fields_dict(type(self)):
+            return getattr(self, attribute_name)
+        if attribute_name in self.attributes:
+            return self.attributes[attribute_name]
+        elif db is not None and attribute_name in db.frame_defines:
+            define = db.frame_defines[attribute_name]
             return define.defaultValue
         return default
 
@@ -823,19 +823,19 @@ class Frame(object):
                 return signal
         return None
 
-    def glob_signals(self, globStr):
+    def glob_signals(self, glob_str):
         # type: (str) -> typing.Sequence[Signal]
         """Find Frame Signals by given glob pattern.
 
-        :param str globStr: glob pattern for signal name. See `fnmatch.fnmatchcase`
+        :param str glob_str: glob pattern for signal name. See `fnmatch.fnmatchcase`
         :return: list of Signals by glob pattern.
         :rtype: list of Signal
         """
-        returnArray = []
+        return_array = []
         for signal in self.signals:
-            if fnmatch.fnmatchcase(signal.name, globStr):
-                returnArray.append(signal)
-        return returnArray
+            if fnmatch.fnmatchcase(signal.name, glob_str):
+                return_array.append(signal)
+        return return_array
 
     def add_attribute(self, attribute, value):
         # type: (str, typing.Any) -> None
@@ -875,11 +875,11 @@ class Frame(object):
 
         :return: Message DLC
         """
-        maxBit = 0
+        max_bit = 0
         for sig in self.signals:
-            if sig.get_startbit() + int(sig.size) > maxBit:
-                maxBit = sig.get_startbit() + int(sig.size)
-        self.size = max(self.size, int(math.ceil(maxBit / 8)))
+            if sig.get_startbit() + int(sig.size) > max_bit:
+                max_bit = sig.get_startbit() + int(sig.size)
+        self.size = max(self.size, int(math.ceil(max_bit / 8)))
 
     def get_frame_layout(self):
         # type: () -> typing.Sequence[typing.Sequence[str]]
@@ -894,8 +894,8 @@ class Frame(object):
         :return: list of lists with signalnames
         :rtype: list of lists
         """
-        little_bits = [[] for _dummy in range((self.size * 8))]  # type: typing.Sequence[typing.MutableSequence]
-        big_bits = [[] for _dummy in range((self.size * 8))]  # type: typing.Sequence[typing.MutableSequence]
+        little_bits = [[] for _dummy in range((self.size * 8))]  # type: typing.List[typing.List]
+        big_bits = [[] for _dummy in range((self.size * 8))]  # type: typing.List[typing.List]
         for signal in self.signals:
             if signal.is_little_endian:
                 least = len(little_bits) - signal.start_bit
@@ -909,15 +909,15 @@ class Frame(object):
                 for big_bit_signals in big_bits[most:least]:
                     big_bit_signals.append(signal)
 
-        little_bits = reversed(tuple(grouper(little_bits, 8)))
-        little_bits = tuple(chain(*little_bits))
+        little_bits_iter = reversed(tuple(grouper(little_bits, 8)))
+        little_bits = list(chain(*little_bits_iter))
 
-        returnList = [
+        return_list = [
             little + big
             for little, big in zip(little_bits, big_bits)
         ]
 
-        return returnList
+        return return_list
 
     def create_dummy_signals(self):  # type: () -> None
         """Create big-endian dummy signals for unused bits.
@@ -971,8 +971,8 @@ class Frame(object):
                     least = most + signal.size
 
                     big_bits[most:least] = bits
-        little_bits = reversed(tuple(grouper(little_bits, 8)))
-        little_bits = tuple(chain(*little_bits))
+        little_bits_iter = reversed(tuple(grouper(little_bits, 8)))
+        little_bits = list(chain(*little_bits_iter))
         bitstring = ''.join(
             next(x for x in (l, b, '0') if x is not None)
             # l if l != ' ' else (b if b != ' ' else '0')
@@ -982,7 +982,6 @@ class Frame(object):
             int(''.join(b), 2)
             for b in grouper(bitstring, 8)
         )
-
 
     def encode(self, data=None):
         # type: (typing.Optional[typing.Mapping[str, typing.Any]]) -> bytes
@@ -1066,6 +1065,7 @@ class Frame(object):
 
         :param data: bytearray
             i.e. bytearray([0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8])
+        :param report_error: set to False to silence error output
         :return: OrderedDictionary
         """
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -609,18 +609,17 @@ class ArbitrationId(object):
 @attr.s(cmp=False)
 class Frame(object):
     """
-    Contains one CAN Frame.
+    Represents CAN Frame.
 
     The Frame has  following mandatory attributes
 
-    * id,
+    * arbitration_id,
     * name,
-    * transmitters (list of boardunits/ECU-names),
-    * size (= DLC),
+    * transmitters (list of ECU names),
+    * size (DLC),
     * signals (list of signal-objects),
     * attributes (list of attributes),
-    * receivers (list of boardunits/ECU-names),
-    * extended (Extended Frame = 1),
+    * receivers (list of ECU names),
     * comment
 
     and any *custom* attributes in `attributes` dict.
@@ -1203,13 +1202,13 @@ class CanMatrix(object):
     """
     The Can-Matrix-Object
     attributes (global canmatrix-attributes),
-    boardUnits (list of boardunits/ECUs),
+    ecus (list of ECUs),
     frames (list of Frames)
-    signalDefines (list of signal-attribute types)
-    frameDefines (list of frame-attribute types)
-    buDefines (list of BoardUnit-attribute types)
-    globalDefines (list of global attribute types)
-    valueTables (global defined values)
+    signal_defines (list of signal-attribute types)
+    frame_defines (list of frame-attribute types)
+    ecu_defines (list of ECU-attribute types)
+    global_defines (list of global attribute types)
+    value_tables (global defined values)
     """
 
     attributes = attr.ib(factory=dict)  # type: typing.MutableMapping[str, typing.Any]

--- a/src/canmatrix/compare.py
+++ b/src/canmatrix/compare.py
@@ -27,7 +27,7 @@ import sys
 import typing
 
 from .log import setup_logger, set_log_level
-import canmatrix.canmatrix as canmatrix
+import canmatrix.canmatrix as cm
 
 logger = logging.getLogger(__name__)
 
@@ -271,7 +271,7 @@ def compareBu(bu1, bu2, ignore=None):
 
 
 def compareFrame(f1, f2, ignore=None):
-    # type: (canmatrix.Frame, canmatrix.Frame, typing.Optional[typing.Mapping[str, typing.Union[str, bool]]]) -> compareResult
+    # type: (cm.Frame, cm.Frame, typing.Optional[typing.Mapping[str, typing.Union[str, bool]]]) -> compareResult
     result = compareResult("equal", "FRAME", f1)
 
     for s1 in f1:

--- a/src/canmatrix/compare.py
+++ b/src/canmatrix/compare.py
@@ -23,9 +23,11 @@
 from __future__ import print_function
 from __future__ import absolute_import
 import logging
+import sys
+import typing
 
 from .log import setup_logger, set_log_level
-import sys
+import canmatrix.canmatrix as canmatrix
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,7 @@ class compareResult(object):
         # reference to related object
         self._ref = ref
         self._changes = changes
-        self._children = []
+        self._children = []  # type: typing.List[compareResult]
 
     def addChild(self, child):
         self._children.append(child)
@@ -269,6 +271,7 @@ def compareBu(bu1, bu2, ignore=None):
 
 
 def compareFrame(f1, f2, ignore=None):
+    # type: (canmatrix.Frame, canmatrix.Frame, typing.Optional[typing.Mapping[str, typing.Union[str, bool]]]) -> compareResult
     result = compareResult("equal", "FRAME", f1)
 
     for s1 in f1:
@@ -297,7 +300,7 @@ def compareFrame(f1, f2, ignore=None):
                     "extended-Flag: %d" %
                     f1.extended, "extended-Flag: %d" %
                     f2.extended]))
-    if not "comment" in ignore:
+    if "comment" not in ignore:
         if f2.comment is None:
             f2.add_comment("")
         if f1.comment is None:
@@ -553,14 +556,13 @@ def main():
     db2 = next(iter(canmatrix.formats.loadp(matrix2).values()))
     logger.info("%d Frames found" % (db2.frames.__len__()))
 
-    ignore = {}
+    ignore = {}  # type: typing.Dict[str, typing.Union[str, bool]]
 
     if not cmdlineOptions.check_comments:
         ignore["comment"] = "*"
 
     if not cmdlineOptions.check_attributes:
         ignore["ATTRIBUTE"] = "*"
-
 
     if cmdlineOptions.ignore_valuetables:
         ignore["VALUETABLES"] = True

--- a/src/canmatrix/compare.py
+++ b/src/canmatrix/compare.py
@@ -293,13 +293,13 @@ def compareFrame(f1, f2, ignore=None):
                     "dlc: %d" %
                     f1.size, "dlc: %d" %
                     f2.size]))
-    if f1.extended != f2.extended:
+    if f1.arbitration_id.extended != f2.arbitration_id.extended:
         result.addChild(
             compareResult(
                 "changed", "FRAME", f1, [
                     "extended-Flag: %d" %
-                    f1.extended, "extended-Flag: %d" %
-                    f2.extended]))
+                    f1.arbitration_id.extended, "extended-Flag: %d" %
+                    f2.arbitration_id.extended]))
     if "comment" not in ignore:
         if f2.comment is None:
             f2.add_comment("")

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -57,7 +57,8 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
             frame_list = options['frames'].split(',')
             db = cm.CanMatrix()
             for frame_name in frame_list:  # type: str
-                canmatrix.copy.copy_frame(frame_name, dbs[name], db)
+                frame_to_copy = dbs[name].frame_by_name(frame_name)  # type: cm.Frame
+                canmatrix.copy.copy_frame(frame_to_copy.arbitration_id, dbs[name], db)
         if options.get('signals', False):
             signal_list = options['signals'].split(',')
             db = cm.CanMatrix()
@@ -85,8 +86,8 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
                             canmatrix.copy.copy_ecu_with_frames(
                                 mergeOpt.split('=')[1], db_temp_list[dbTemp], db)
                         if mergeOpt.split('=')[0] == "frame":
-                            canmatrix.copy.copy_frame(
-                                mergeOpt.split('=')[1], db_temp_list[dbTemp], db)
+                            frame_to_copy = dbs[name].frame_by_name(mergeOpt.split('=')[1])
+                            canmatrix.copy.copy_frame(frame_to_copy.arbitration_id, db_temp_list[dbTemp], db)
 
         if 'renameEcu' in options and options['renameEcu'] is not None:
             rename_tuples = options['renameEcu'].split(',')
@@ -111,8 +112,8 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
             for touple in touples:
                 (frameName, ecu) = touple.split(':')
                 frames = db.glob_frames(frameName)
-                for frame in frames:  # type: canmatrix.Frame
-                    for signal in frame.signals:  # type: canmatrix.Signal
+                for frame in frames:  # type: cm.Frame
+                    for signal in frame.signals:  # type: cm.Signal
                         signal.add_receiver(ecu)
                     frame.update_receiver()
 
@@ -124,7 +125,7 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
             change_tuples = options['changeFrameId'].split(',')
             for renameTuple in change_tuples:
                 old, new = renameTuple.split(':')
-                frame = db.frame_by_id(canmatrix.ArbitrationId(int(old)))
+                frame = db.frame_by_id(cm.ArbitrationId(int(old)))
                 if frame is not None:
                     frame.arbitration_id.id = int(new)
                 else:
@@ -144,7 +145,7 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
                     frame_ptr.is_fd = False
 
         if 'skipLongDlc' in options and options['skipLongDlc'] is not None:
-            delete_frame_list = []  # type: typing.List[canmatrix.Frame]
+            delete_frame_list = []  # type: typing.List[cm.Frame]
             for frame in db.frames:
                 if frame.size > int(options['skipLongDlc']):
                     delete_frame_list.append(frame)

--- a/src/canmatrix/copy.py
+++ b/src/canmatrix/copy.py
@@ -26,13 +26,13 @@ import copy
 import logging
 import typing
 
-import canmatrix.canmatrix as canmatrix
+import canmatrix.canmatrix as cm
 
 logger = logging.getLogger(__name__)
 
 
 def copy_ecu(ecu_or_glob, source_db, target_db):
-    # type: (typing.Union[canmatrix.Ecu, str], canmatrix.CanMatrix, canmatrix.CanMatrix) -> None
+    # type: (typing.Union[cm.Ecu, str], cm.CanMatrix, cm.CanMatrix) -> None
     """
     Copy ECU(s) identified by Name or as Object from source CAN matrix to target CAN matrix.
     This function additionally copy all relevant Defines.
@@ -42,7 +42,7 @@ def copy_ecu(ecu_or_glob, source_db, target_db):
     :param target_db: Destination CAN matrix
     """
     # check whether ecu_or_glob is object or symbolic name
-    if isinstance(ecu_or_glob, canmatrix.Ecu):
+    if isinstance(ecu_or_glob, cm.Ecu):
         ecu_list = [ecu_or_glob]
     else:
         ecu_list = source_db.glob_ecus(ecu_or_glob)
@@ -66,7 +66,7 @@ def copy_ecu(ecu_or_glob, source_db, target_db):
 
 
 def copy_ecu_with_frames(ecu_or_glob, source_db, target_db):
-    # type: (typing.Union[canmatrix.Ecu, str], canmatrix.CanMatrix, canmatrix.CanMatrix) -> None
+    # type: (typing.Union[cm.Ecu, str], cm.CanMatrix, cm.CanMatrix) -> None
     """
     Copy ECU(s) identified by Name or as Object from source CAN matrix to target CAN matrix.
     This function additionally copy all relevant Frames and Defines.
@@ -76,7 +76,7 @@ def copy_ecu_with_frames(ecu_or_glob, source_db, target_db):
     :param target_db: Destination CAN matrix
     """
     # check whether ecu_or_glob is object or symbolic name
-    if isinstance(ecu_or_glob, canmatrix.Ecu):
+    if isinstance(ecu_or_glob, cm.Ecu):
         ecu_list = [ecu_or_glob]
     else:
         ecu_list = source_db.glob_ecus(ecu_or_glob)
@@ -114,7 +114,7 @@ def copy_ecu_with_frames(ecu_or_glob, source_db, target_db):
 
 
 def copy_signal(signal_glob, source_db, target_db):
-    # type: (str, canmatrix.CanMatrix, canmatrix.CanMatrix) -> None
+    # type: (str, cm.CanMatrix, cm.CanMatrix) -> None
     """
     Copy Signals identified by name from source CAN matrix to target CAN matrix.
     In target CanMatrix the signal is put without frame, just on top level.
@@ -129,7 +129,7 @@ def copy_signal(signal_glob, source_db, target_db):
 
 
 def copy_frame(frame_id, source_db, target_db):
-    # type: (canmatrix.ArbitrationId, canmatrix.CanMatrix, canmatrix.CanMatrix) -> bool
+    # type: (cm.ArbitrationId, cm.CanMatrix, cm.CanMatrix) -> bool
     """
     Copy a Frame identified by ArbitrationId from source CAN matrix to target CAN matrix.
     This function additionally copy all relevant ECUs and Defines.

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -271,8 +271,8 @@ def test_signal_set_default_min_max():
 def test_signal_decode_named_value(some_signal):
     some_signal.add_values(255, "Init")
     some_signal.add_values(254, "Error")
-    assert some_signal.raw2phys(254, decodeToStr=True) == "Error"
-    assert some_signal.raw2phys(200, decodeToStr=True) == 200
+    assert some_signal.raw2phys(254, decode_to_str=True) == "Error"
+    assert some_signal.raw2phys(200, decode_to_str=True) == 200
 
 
 def test_signal_encode_named_value(some_signal):


### PR DESCRIPTION
- Try to decrease mypy warnings to minimum (CI would need to solve _all of them_)
- Plus some snake_case and BU removal
- Added some "help" to mypy config file
- I silenced (lot of) mypy warnings about "null pointers" - For example the `db.frame_by_name()` might return `None` but is never checked (maybe `raise` an exception instead of returning `None` in the future...)
- There are still about 17 mypy errors, mostly caused by float factory used as `converter`, and 3 real bugs in `compare` module (canmatrix\compare.py:296:8: error: "Frame" has no attribute "extended" ... @ebroecker could you check this please?).
- (And whole `formats` module is not checked yet)

Generally I already see benefits of the type annotations, mypy has actually pointed some bugs.