### PR TITLE
hashed dbc import

### DIFF
--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -450,6 +450,20 @@ def load(f, **options):
     frame = None
     boardUnit = None
     db = canmatrix.CanMatrix()
+    framesById = {}
+    
+    def hash_arbitration_id(arbitration_id):
+        return hash((arbitration_id.id, arbitration_id.extended))
+
+    def get_frame_by_id(arbitration_id):
+        try:
+            return framesById[hash_arbitration_id(arbitration_id)]
+        except KeyError:
+            return None
+            
+    def add_frame_by_id(frame):
+        framesById[hash_arbitration_id(frame.arbitration_id)] = frame
+
     for line in f:
         i = i + 1
         l = line.strip()
@@ -498,6 +512,7 @@ def load(f, **options):
                 frame = canmatrix.Frame(temp.group(2),arbitration_id = int(temp.group(1)),
                                         size=int(temp.group(3)), transmitters=temp.group(4).split())
                 db.frames.append(frame)
+                add_frame_by_id(frame)
             elif decoded.startswith("SG_ "):
                 pattern = r"^SG_ +(\w+) *: *(\d+)\|(\d+)@(\d+)([\+|\-]) +\(([0-9.+\-eE]+),([0-9.+\-eE]+)\) +\[([0-9.+\-eE]+)\|([0-9.+\-eE]+)\] +\"(.*)\" +(.*)"
                 regexp = re.compile(pattern)
@@ -589,7 +604,7 @@ def load(f, **options):
             elif decoded.startswith("BO_TX_BU_ "):
                 regexp = re.compile(r"^BO_TX_BU_ ([0-9]+) *: *(.+);")
                 temp = regexp.match(decoded)
-                frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                 for ecu in temp.group(2).split(','):
                     frame.add_transmitter(ecu)
             elif decoded.startswith("CM_ SG_ "):
@@ -599,7 +614,7 @@ def load(f, **options):
                 temp = regexp.match(decoded)
                 temp_raw = regexp_raw.match(l)
                 if temp:
-                    frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                    frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                     signal = frame.signal_by_name(temp.group(2))
                     if signal:
                         try:
@@ -616,7 +631,7 @@ def load(f, **options):
                     temp = regexp.match(decoded)
                     temp_raw = regexp_raw.match(l)
                     if temp:
-                        frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                        frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                         signal = frame.signal_by_name(temp.group(2))
                         try:
                             comment = temp_raw.group(3).decode(
@@ -634,7 +649,7 @@ def load(f, **options):
                 temp = regexp.match(decoded)
                 temp_raw = regexp_raw.match(l)
                 if temp:
-                    frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                    frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                     if frame:
                         try:
                             frame.add_comment(temp_raw.group(2).decode(
@@ -650,7 +665,7 @@ def load(f, **options):
                     temp = regexp.match(decoded)
                     temp_raw = regexp_raw.match(l)
                     if temp:
-                        frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                        frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                         try:
                             comment = temp_raw.group(2).decode(
                                 dbcCommentEncoding).replace('\\"', '"')
@@ -712,7 +727,7 @@ def load(f, **options):
                     tempList = temp.group(3).split('"')
                     if frame_id.isnumeric(): # value for Frame
                         try:
-                            frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(frame_id)))
+                            frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(frame_id)))
                             sg = frame.signal_by_name(signal)
                             for i in range(math.floor(len(tempList) / 2)):
                                 val = tempList[i * 2 + 1]
@@ -777,13 +792,13 @@ def load(f, **options):
                 if tempba.group(1).strip().startswith("BO_ "):
                     regexp = re.compile(r"^BA_ +\"(.*)\" +BO_ +(\w+) +(.+);")
                     temp = regexp.match(decoded)
-                    db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(2)))).add_attribute(
+                    get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(2)))).add_attribute(
                         temp.group(1), temp.group(3))
                 elif tempba.group(1).strip().startswith("SG_ "):
                     regexp = re.compile(r"^BA_ +\"(.*)\" +SG_ +(\w+) +(\w+) +(.+);")
                     temp = regexp.match(decoded)
                     if temp != None:
-                        db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(2)))).signal_by_name(
+                        get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(2)))).signal_by_name(
                             temp.group(3)).add_attribute(temp.group(1), temp.group(4))
                 elif tempba.group(1).strip().startswith("EV_ "):
                     regexp = re.compile(r"^BA_ +\"(.*)\" +EV_ +(.+) +(.+);")
@@ -807,7 +822,7 @@ def load(f, **options):
             elif decoded.startswith("SIG_GROUP_ "):
                 regexp = re.compile(r"^SIG_GROUP_ +(\w+) +(\w+) +(\w+) +\:(.*);")
                 temp = regexp.match(decoded)
-                frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                 if frame is not None:
                     signalArray = temp.group(4).split(' ')
                     frame.add_signal_group(temp.group(2), temp.group(3), signalArray)
@@ -815,7 +830,7 @@ def load(f, **options):
             elif decoded.startswith("SIG_VALTYPE_ "):
                 regexp = re.compile(r"^SIG_VALTYPE_ +(\w+) +(\w+)\s*\:(.*);")
                 temp = regexp.match(decoded)
-                frame = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
+                frame = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(temp.group(1))))
                 if frame:
                     signal = frame.signal_by_name(temp.group(2))
                     signal.is_float = True
@@ -842,7 +857,7 @@ def load(f, **options):
                     muxerForSignal = temp.group(3)
                     muxValMin = int(temp.group(4))
                     muxValMax = int(temp.group(4))
-                    frame  = db.frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(frameId)))
+                    frame  = get_frame_by_id(canmatrix.ArbitrationId.from_compound_integer(int(frameId)))
                     if frame is not None:
                         signal = frame.signal_by_name(signalName)
                         frame.is_complex_multiplexed = True


### PR DESCRIPTION
created a hashed list of frames to speedup the import process of dbc files, in my example i used a dbc file with 65k lines and around 800 frames.

before ...
 ```
 Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    50600    5.286    0.000    8.465    0.000 canmatrix.py:1390(frame_by_id)
 25100584    3.180    0.000    3.180    0.000 canmatrix.py:600(__eq__)
        1    0.452    0.452    9.610    9.610 canmatrix\formats\dbc.py:437(load)
   110409    0.117    0.000    0.117    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
```

after ...
   ```
Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.388    0.388    1.190    1.190 canmatrix\formats\dbc.py:437(load)
      791    0.131    0.000    0.134    0.000 {built-in method builtins.print}
   110409    0.104    0.000    0.104    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
   759393    0.078    0.000    0.078    0.000 {method 'startswith' of 'str' objects}
```

so it reduced the overall time needed to import that specific dbc file from 9 to 1 seconds on an i7-8550U at 3,9 GHz.

We are able to do this, because the Frame Objects are mutable anyway and stored in the db by reference. 