### PR TITLE
- rely on del_transmitter and del_receiver

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -1564,11 +1564,11 @@ class CanMatrix(object):
             if ecu in self.ecus:
                 self.ecus.remove(ecu)
                 for frame in self.frames:
-                    if ecu.name in frame.transmitters:
-                        frame.transmitters.remove(ecu.name)
+                    frame.del_transmitter(ecu.name)
+					
                     for signal in frame.signals:
-                        if ecu.name in signal.receivers:
-                            signal.receivers.remove(ecu.name)
+                        signal.del_receiver(ecu.name)
+
                     frame.update_receiver()
 
     def update_ecu_list(self):  # type: () -> None


### PR DESCRIPTION
i stumbled over these lines of code the other day as they throw an AttributeError as there was an misspelling in

`signal.receivers.remove(ecu.name)`

and i thought, maybe we should rely on _del_transmitter_ and _del_receiver_ to be consistent with _frame.update_receiver()_.