### PR TITLE
Explicit import in init and add some typing

### DIFF
--- a/src/canmatrix/__init__.py
+++ b/src/canmatrix/__init__.py
@@ -8,6 +8,29 @@ __version__ = canmatrix._version.get_versions()['version']
 
 import canmatrix.formats as formats
 import canmatrix.cancluster as cancluster
+
+from canmatrix.canmatrix import (
+    Ecu,
+    Signal,
+    SignalGroup,
+    DecodedSignal,
+    ArbitrationId,
+    Frame,
+    Define,
+    CanMatrix,
+    CanId
+)
+
+from canmatrix.canmatrix import (
+    StartbitLowerZero,
+    EncodingComplexMultiplexed,
+    MissingMuxSignal,
+    DecodingComplexMultiplexed,
+    DecodingFrameLength,
+    ArbitrationIdOutOfRange
+)
+
+# todo remove this later
 from canmatrix.canmatrix import *
 
 # Set default logging handler to avoid "No handler found" warnings in python 2.


### PR DESCRIPTION
- Add explicit imports to `canmatrix.__init__`, still leaving the import * (to be deleted later when we decide, that the export list is enough). Note the mypy doesn't handle the `import *` correctly and produce false errors.
- Add converter function for `ArbitrationId`, because the classmethod converter is not supported by mypy and moreover the `from_compound_integer()` as converter effectively disallow the `Frame.arbitration_id` to be initialized directy by `ArbitrationId` instance.

all changes mainly targeted to reduce static typing issues.