### PR TITLE
Fix #326: Always use Signal.is_little_endian as bool

### DIFF
--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1144,7 +1144,7 @@ def get_signals(signal_array, frame, root_or_cache, ns, multiplex_id, float_fact
             if signal_max is not None:
                 new_signal.max = signal_max
 
-            if new_signal.is_little_endian == 0:
+            if not new_signal.is_little_endian:
                 # startbit of motorola coded signals are MSB in arxml
                 new_signal.set_startbit(int(start_bit.text), bitNumbering=1)
 

--- a/src/canmatrix/formats/cmjson.py
+++ b/src/canmatrix/formats/cmjson.py
@@ -83,7 +83,7 @@ def dump(db, f, **options):
                     "bit_length": signal.size,
                     "factor": str(signal.factor),
                     "offset": str(signal.offset),
-                    "is_big_endian": signal.is_little_endian == 0,
+                    "is_big_endian": signal.is_little_endian is False,
                     "is_signed": signal.is_signed,
                     "is_float": signal.is_float
                 })
@@ -124,7 +124,7 @@ def dump(db, f, **options):
                     "offset": str(signal.offset),
                     "min": str(signal.min),
                     "max": str(signal.max),
-                    "is_big_endian": signal.is_little_endian == 0,
+                    "is_big_endian": signal.is_little_endian is False,
                     "is_signed": signal.is_signed,
                     "is_float": signal.is_float,
                     "comment": signal.comment,

--- a/src/canmatrix/formats/sym.py
+++ b/src/canmatrix/formats/sym.py
@@ -111,7 +111,7 @@ def create_signal(db, signal):  # type: (canmatrix.CanMatrix, canmatrix.Signal) 
     else:
         output += "signed "
     start_bit = signal.get_startbit()
-    if signal.is_little_endian == 0:
+    if not signal.is_little_endian:
         # Motorola
         output += "%d,%d -m " % (start_bit, signal.size)
     else:


### PR DESCRIPTION
Remove is_little_endian comparicons with zero and one. (fix #326)