### PR TITLE
fix: xls is using the wrong number for arbitration id

### DIFF
--- a/src/canmatrix/formats/xls.py
+++ b/src/canmatrix/formats/xls.py
@@ -421,7 +421,7 @@ def load(file, **options):
             if frame_id.endswith("xh"):
                 new_frame.arbitration_id = canmatrix.ArbitrationId(int(frame_id[:-2], 16), extended=True)
             else:
-                new_frame.arbitration_id = canmatrix.ArbitrationId(int(frame_id[:-2], 16), extended=False)
+                new_frame.arbitration_id = canmatrix.ArbitrationId(int(frame_id[:-1], 16), extended=False)
             db.add_frame(new_frame)
 
             # eval launch_type


### PR DESCRIPTION
When loading xls, the arbitration id is misinterpeted by one character. This leads to wrong ids.