### PR TITLE
Update Scapy format

### DIFF
--- a/src/canmatrix/formats/scapy.py
+++ b/src/canmatrix/formats/scapy.py
@@ -53,20 +53,11 @@ def dump(db, f, **options):  # type: (canmatrix.CanMatrix, typing.IO, **typing.A
     from scapy.packet import bind_layers
     from scapy.fields import *
     from scapy.layers.can import *
-    class DBC(CAN):
-        name = 'DBC'
-        fields_desc = [
-            FlagsField('flags', 0, 3, ['error',
-                                       'remote_transmission_request',
-                                       'extended']),
-            XBitField('arbitration_id', 0, 29),
-            ByteField('length', None),
-            ThreeBytesField('reserved', 0),
-        ]
+    
     """)
 
     for frame in db.frames:
-        scapy_decoder += "class " + frame.name + "(Packet):\n"
+        scapy_decoder += "class " + frame.name + "(SignalPacket):\n"
         scapy_decoder += "    fields_desc = [ \n"
 
         for signal in frame.signals:
@@ -77,10 +68,10 @@ def dump(db, f, **options):  # type: (canmatrix.CanMatrix, typing.IO, **typing.A
 
     for frame in db.frames:
         if frame.arbitration_id.extended:
-            scapy_decoder += "bind_layers(DBC, " + frame.name + ", arbitration_id = " + hex(
+            scapy_decoder += "bind_layers(SignalHeader, " + frame.name + ", identifier = " + hex(
                 frame.arbitration_id.id) + ", flags = extended)\n"
         else:
-            scapy_decoder += "bind_layers(DBC, " + frame.name + ", arbitration_id = " + hex(
+            scapy_decoder += "bind_layers(SignalHeader, " + frame.name + ", identifier = " + hex(
                 frame.arbitration_id.id) + ")\n"
 
     f.write(scapy_decoder.encode("utf8"))

--- a/src/canmatrix/tests/test_scapy.py
+++ b/src/canmatrix/tests/test_scapy.py
@@ -8,8 +8,7 @@ def test_scapy_frame_exists():
     outscapy = io.BytesIO()
     canmatrix.formats.dump(db, outscapy, "scapy")
 
-    assert "class some_frame(Packet):" in outscapy.getvalue().decode("utf8")
-    assert "class DBC(CAN)" in outscapy.getvalue().decode("utf8")
+    assert "class some_frame(SignalPacket):" in outscapy.getvalue().decode("utf8")
 
 def test_scapy_signal_exists():
     db = canmatrix.CanMatrix()


### PR DESCRIPTION
I've updated the implementation of SignalFields in Scapy. This should keep canmatrix up-to-date, as well.
This PR can be merged, after https://github.com/secdev/scapy/pull/2253 is merged into mainline Scapy.