### PR TITLE
[try to] Unify imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml
 future
 attrs>=18.1.0
 typing; python_version < '3.5'
+pathlib2

--- a/src/canmatrix/cancluster.py
+++ b/src/canmatrix/cancluster.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import typing
+from builtins import *
 
 import canmatrix
 

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -26,23 +26,20 @@
 
 # TODO: Definitions should be disassembled
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division, print_function
 
 import decimal
 import fnmatch
+import itertools
 import logging
 import math
 import struct
 import typing
-from itertools import chain
+from builtins import *
 
-try:
-    from itertools import zip_longest as zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest  # type: ignore
-
-from past.builtins import basestring
 import attr
+from future.moves.itertools import zip_longest
+from past.builtins import basestring
 
 import canmatrix.copy
 import canmatrix.types
@@ -1057,7 +1054,7 @@ class Frame(object):
                     big_bit_signals.append(signal)
 
         little_bits_iter = reversed(tuple(grouper(little_bits, 8)))
-        little_bits = list(chain(*little_bits_iter))
+        little_bits = list(itertools.chain(*little_bits_iter))
 
         return_list = [
             little + big
@@ -1119,7 +1116,7 @@ class Frame(object):
 
                     big_bits[most:least] = bits
         little_bits_iter = reversed(tuple(grouper(little_bits, 8)))
-        little_bits = list(chain(*little_bits_iter))
+        little_bits = list(itertools.chain(*little_bits_iter))
         bitstring = ''.join(
             next(x for x in (l, b, '0') if x is not None)
             # l if l != ' ' else (b if b != ' ' else '0')

--- a/src/canmatrix/cli/compare.py
+++ b/src/canmatrix/cli/compare.py
@@ -21,12 +21,13 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import logging
 import sys
 import typing
+from builtins import *
+
 import click
 
 import canmatrix.compare

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -21,8 +21,7 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import logging
 import sys

--- a/src/canmatrix/compare.py
+++ b/src/canmatrix/compare.py
@@ -19,13 +19,12 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import logging
-import optparse
 import sys
 import typing
+from builtins import *
 
 import attr
 

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -19,12 +19,12 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import logging
 import sys
 import typing
+from builtins import *
 
 import canmatrix
 import canmatrix.copy

--- a/src/canmatrix/copy.py
+++ b/src/canmatrix/copy.py
@@ -19,11 +19,12 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import copy
 import logging
 import typing
+from builtins import *
 
 import canmatrix
 

--- a/src/canmatrix/formats/__init__.py
+++ b/src/canmatrix/formats/__init__.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
-from importlib import import_module
-import sys
+from __future__ import absolute_import, division, print_function
+
+import importlib
 import logging
 import os
+import sys
 import typing
 
 import canmatrix
 import canmatrix.cancluster
+
 if sys.version_info > (3, 0):
     import io
 else:
@@ -21,7 +24,7 @@ extensionMapping = {}
 
 for module in moduleList:
     try:
-        import_module("canmatrix.formats." + module)
+        importlib.import_module("canmatrix.formats." + module)
         loadedFormats.append(module)
     except ImportError:
         logger.info("%s is not supported", module)

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -24,16 +24,14 @@
 # arxml-files are the can-matrix-definitions and a lot more in AUTOSAR-Context
 # currently Support for Autosar 3.2 and 4.0-4.3 is planned
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import decimal
 import logging
 import typing
 from builtins import *
 
-from lxml import etree
+import lxml.etree
 
 import canmatrix
 import canmatrix.types
@@ -47,7 +45,7 @@ clusterImporter = 1
 
 
 class ArTree(object):
-    def __init__(self, name="", ref=None):  # type: (str, etree._Element) -> None
+    def __init__(self, name="", ref=None):  # type: (str, lxml.etree._Element) -> None
         self._name = name
         self._ref = ref
         self._array = []  # type: typing.List[ArTree]
@@ -65,12 +63,12 @@ class ArTree(object):
         return None
 
     @property
-    def ref(self):  # type: () -> etree._Element
+    def ref(self):  # type: () -> lxml.etree._Element
         return self._ref
 
 
 # for typing only
-_Element = etree._Element
+_Element = lxml.etree._Element
 _DocRoot = typing.Union[_Element, ArTree]
 _MultiplexId = typing.Union[str, int, None]
 _FloatFactory = typing.Callable[[typing.Any], typing.Any]
@@ -78,7 +76,7 @@ _FloatFactory = typing.Callable[[typing.Any], typing.Any]
 
 def create_sub_element(parent, element_name, text=None):
     # type: (_Element, str, typing.Optional[str]) -> _Element
-    sn = etree.SubElement(parent, element_name)
+    sn = lxml.etree.SubElement(parent, element_name)
     if text is not None:
         sn.text = str(text)
     return sn
@@ -135,7 +133,7 @@ def dump(dbs, f, **options):
 
     if ar_version[0] == "3":
         xsi = 'http://www.w3.org/2001/XMLSchema-instance'
-        root = etree.Element(
+        root = lxml.etree.Element(
             'AUTOSAR',
             nsmap={
                 None: 'http://autosar.org/' + ar_version,
@@ -145,7 +143,7 @@ def dump(dbs, f, **options):
         top_level_packages = create_sub_element(root, 'TOP-LEVEL-PACKAGES')
     else:
         xsi = 'http://www.w3.org/2001/XMLSchema-instance'
-        root = etree.Element(
+        root = lxml.etree.Element(
             'AUTOSAR',
             nsmap={
                 None: "http://autosar.org/schema/r4.0",
@@ -760,7 +758,7 @@ def dump(dbs, f, **options):
                 ipdu_ref.set('DEST', "I-SIGNAL-I-PDU")
                 ipdu_ref.text = "/PDU/PDU_" + frame_name
 
-    f.write(etree.tostring(root, pretty_print=True, xml_declaration=True))
+    f.write(lxml.etree.tostring(root, pretty_print=True, xml_declaration=True))
 
 
 ###################################
@@ -1000,7 +998,7 @@ def get_signals(signal_array, frame, root_or_cache, ns, multiplex_id, float_fact
 
         base_type = get_child(isignal, "BASE-TYPE", root_or_cache, ns)
         try:
-            type_encoding = get_child(base_type,"BASE-TYPE-ENCODING", root_or_cache, ns).text
+            type_encoding = get_child(base_type, "BASE-TYPE-ENCODING", root_or_cache, ns).text
         except AttributeError:
             type_encoding = "None"
         signal_name = None  # type: typing.Optional[str]
@@ -1192,6 +1190,7 @@ def get_signals(signal_array, frame, root_or_cache, ns, multiplex_id, float_fact
                 new_signal.add_attribute("LongName", signal_name)
             frame.add_signal(new_signal)
 
+
 def get_frame_from_multiplexed_ipdu(pdu, target_frame, multiplex_translation, root_or_cache, ns, float_factory):
     selector_byte_order = get_child(pdu, "SELECTOR-FIELD-BYTE-ORDER", root_or_cache, ns)
     selector_len = get_child(pdu, "SELECTOR-FIELD-LENGTH", root_or_cache, ns)
@@ -1244,8 +1243,8 @@ def get_frame_from_container_ipdu(pdu, target_frame, root_or_cache, ns, float_fa
     header_type = get_child(pdu, "HEADER-TYPE", root_or_cache, ns).text
     if header_type == "SHORT-HEADER":
         header_length = 32
-        target_frame.add_signal(canmatrix.Signal(start_bit=0, size=24, name="Header_ID", multiplex ="Multiplexor", is_little_endian = True))
-        target_frame.add_signal(canmatrix.Signal(start_bit=24, size= 8, name="Header_DLC", is_little_endian = True))
+        target_frame.add_signal(canmatrix.Signal(start_bit=0, size=24, name="Header_ID", multiplex="Multiplexor", is_little_endian=True))
+        target_frame.add_signal(canmatrix.Signal(start_bit=24, size=8, name="Header_DLC", is_little_endian=True))
     elif header_type == "LONG-HEADER":
         header_length = 64
         target_frame.add_signal(canmatrix.Signal(start_bit=0, size=32, name="Header_ID", multiplex="Multiplexor",
@@ -1254,7 +1253,7 @@ def get_frame_from_container_ipdu(pdu, target_frame, root_or_cache, ns, float_fa
     else:
         raise("header " + header_type + " not supported for containers yet")
         # none type
-        #TODO
+        # TODO
 
     for cpdu in pdus:
         ipdu = get_child(cpdu, "I-PDU", root_or_cache, ns)
@@ -1264,7 +1263,7 @@ def get_frame_from_container_ipdu(pdu, target_frame, root_or_cache, ns, float_fa
             elif header_type == "LONG-HEADER":
                 header_id = get_child(ipdu, "HEADER-ID-LONG-HEADER", root_or_cache, ns).text
             else:
-                #none type
+                # none type
                 pass
         except AttributeError:
             header_id = "0"
@@ -1285,6 +1284,7 @@ def get_frame_from_container_ipdu(pdu, target_frame, root_or_cache, ns, float_fa
             target_frame.add_signal_group("HEARDER_ID_" + str(header_id), signal_group_id, new_signals)
             singnals_grouped += new_signals
             signal_group_id += 1
+
 
 def store_frame_timings(target_frame, cyclic_timing, event_timing, minimum_delay, repeats, starting_time, time_offset, repeating_time, root_or_cache, time_period, ns, float_factory):
     if cyclic_timing is not None and event_timing is not None:
@@ -1602,7 +1602,7 @@ def load(file, **options):
 
     result = {}
     logger.debug("Read arxml ...")
-    tree = etree.parse(file)
+    tree = lxml.etree.parse(file)
 
     root = tree.getroot()  # type: _Element
     logger.debug(" Done\n")
@@ -1650,7 +1650,7 @@ def load(file, **options):
     logger.debug("%d I-SIGNAL-TO-I-PDU-MAPPING in arxml...", len(sig_ipdu))
 
     if ignore_cluster_info is True:
-        ccs = [etree.Element("ignoreClusterInfo")]  # type: typing.Sequence[_Element]
+        ccs = [lxml.etree.Element("ignoreClusterInfo")]  # type: typing.Sequence[_Element]
     else:
         ccs = root.findall('.//' + ns + 'CAN-CLUSTER')
     for cc in ccs:  # type: _Element

--- a/src/canmatrix/formats/csv.py
+++ b/src/canmatrix/formats/csv.py
@@ -23,13 +23,14 @@
 # this script exports canmatrix-objects to a CSV file. (Based on xlsx)
 # Author: Martin Hoffmann (m8ddin@gmail.com)
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import collections
 import csv
 import logging
 import sys
 import typing
+from builtins import *
 
 import canmatrix.formats.xls_common
 

--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -23,9 +23,7 @@
 # this script exports dbc-files from a canmatrix-object
 # dbc-files are the can-matrix-definitions of the CANoe (Vector Informatic)
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import collections
 import copy

--- a/src/canmatrix/formats/dbf.py
+++ b/src/canmatrix/formats/dbf.py
@@ -23,9 +23,7 @@
 # this script imports dbf-files in a canmatrix-object
 # dbf-files are the can-matrix-definitions of the busmaster-project (http://rbei-etas.github.io/busmaster/)
 #
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import copy
 import decimal
@@ -33,6 +31,7 @@ import logging
 import math
 import re
 import typing
+from builtins import *
 
 import canmatrix
 

--- a/src/canmatrix/formats/fibex.py
+++ b/src/canmatrix/formats/fibex.py
@@ -25,11 +25,12 @@
 # only (fibex: Field Bus Exchange Format //
 # https://de.wikipedia.org/wiki/Field_Bus_Exchange_Format)
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import typing
 from builtins import *
-from lxml import etree
+
+import lxml.etree
 
 import canmatrix
 
@@ -45,20 +46,20 @@ ns_xsi = "{%s}" % xsi
 extension = "xml"
 
 # noinspection PyProtectedMember
-_Element = etree._Element
+_Element = lxml.etree._Element
 
 
 def create_short_name_desc(parent, short_name, desc):
     # type: (_Element, str, str) -> None
-    short_name_elem = etree.SubElement(parent, ns_ho + "SHORT-NAME")
+    short_name_elem = lxml.etree.SubElement(parent, ns_ho + "SHORT-NAME")
     short_name_elem.text = short_name
-    desc_elem = etree.SubElement(parent, ns_ho + "DESC")
+    desc_elem = lxml.etree.SubElement(parent, ns_ho + "DESC")
     desc_elem.text = desc
 
 
 def create_sub_element_fx(parent, element_name, element_text=None):
     # type: (_Element, str, typing.Optional[str]) -> _Element
-    new = etree.SubElement(parent, ns_fx + element_name)
+    new = lxml.etree.SubElement(parent, ns_fx + element_name)
     if element_text is not None:
         new.text = element_text
     return new
@@ -66,7 +67,7 @@ def create_sub_element_fx(parent, element_name, element_text=None):
 
 def create_sub_element_ho(parent, element_name, element_text=None):
     # type: (_Element, str, typing.Optional[str]) -> _Element
-    new = etree.SubElement(parent, ns_ho + element_name)
+    new = lxml.etree.SubElement(parent, ns_ho + element_name)
     if element_text is not None:
         new.text = element_text
     return new
@@ -75,7 +76,7 @@ def create_sub_element_ho(parent, element_name, element_text=None):
 def dump(db, f, **options):
     # type: (canmatrix.CanMatrix, typing.IO, **typing.Any) -> None
     ns_map = {"fx": fx, "ho": ho, "can": can, "xsi": xsi}
-    root = etree.Element(ns_fx + "FIBEX", nsmap=ns_map)
+    root = lxml.etree.Element(ns_fx + "FIBEX", nsmap=ns_map)
     root.attrib[
         '{{{pre}}}schemaLocation'.format(
             pre=xsi)] = 'http://www.asam.net/xml/fbx ..\\..\\xml_schema\\fibex.xsd http://www.asam.net/xml/fbx/can  ..\\..\\xml_schema\\fibex4can.xsd'
@@ -96,7 +97,7 @@ def dump(db, f, **options):
     # CLUSTERS
     #
     clusters = create_sub_element_fx(elements, "CLUSTERS")
-    cluster = etree.SubElement(clusters, ns_fx + "CLUSTER")
+    cluster = lxml.etree.SubElement(clusters, ns_fx + "CLUSTER")
     cluster.set('ID', 'canCluster1')
     create_short_name_desc(cluster, "clusterShort", "clusterDesc")
     create_sub_element_fx(cluster, "SPEED", "500")
@@ -200,7 +201,7 @@ def dump(db, f, **options):
                 if bu.name in signal.receivers:
                     input_port = create_sub_element_fx(input_ports, "INPUT-PORT")
                     input_port.set("ID", "INP_" + signal.name)
-                    desc = etree.SubElement(input_port, ns_ho + "DESC")
+                    desc = lxml.etree.SubElement(input_port, ns_ho + "DESC")
                     desc.text = signal.comment
                     signal_ref = create_sub_element_fx(input_port, "SIGNAL-REF")
                     signal_ref.set("ID-REF", "SIG_" + signal.name)
@@ -210,7 +211,7 @@ def dump(db, f, **options):
                 for signal in frame.signals:
                     output_port = create_sub_element_fx(input_ports, "OUTPUT-PORT")
                     output_port.set("ID", "OUTP_" + signal.name)
-                    desc = etree.SubElement(output_port, ns_ho + "DESC")
+                    desc = lxml.etree.SubElement(output_port, ns_ho + "DESC")
                     desc.text = "signalcomment"
                     signal_ref = create_sub_element_fx(output_port, "SIGNAL-REF")
                     signal_ref.set("ID-REF", "SIG_" + signal.name)
@@ -230,7 +231,7 @@ def dump(db, f, **options):
     #
     # PROCESSING-INFORMATION
     #
-    proc_info = etree.SubElement(elements, ns_fx + "PROCESSING-INFORMATION", nsmap={"ho": ho})
+    proc_info = lxml.etree.SubElement(elements, ns_fx + "PROCESSING-INFORMATION", nsmap={"ho": ho})
     unit_spec = create_sub_element_ho(proc_info, "UNIT-SPEC")
     for frame in db.frames:
         for signal in frame.signals:
@@ -286,4 +287,4 @@ def dump(db, f, **options):
     #
     # requirements = createSubElementFx(elements,  "REQUIREMENTS")
 
-    f.write(etree.tostring(root, pretty_print=True))
+    f.write(lxml.etree.tostring(root, pretty_print=True))

--- a/src/canmatrix/formats/json.py
+++ b/src/canmatrix/formats/json.py
@@ -24,7 +24,7 @@
 # json-files are the can-matrix-definitions of the CANard-project
 # (https://github.com/ericevenchick/CANard)
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import json
 import sys

--- a/src/canmatrix/formats/scapy.py
+++ b/src/canmatrix/formats/scapy.py
@@ -22,8 +22,11 @@
 # this script exports scapy python files
 # https://scapy.readthedocs.io/en/latest/advanced_usage.html#automotive-usage
 
+from __future__ import absolute_import, division, print_function
+
 import textwrap
 import typing
+from builtins import *
 
 import canmatrix
 

--- a/src/canmatrix/formats/sym.py
+++ b/src/canmatrix/formats/sym.py
@@ -23,8 +23,7 @@
 # this script exports sym-files from a canmatrix-object
 # sym-files are the can-matrix-definitions of the Peak Systems Tools
 
-from __future__ import absolute_import
-from __future__ import division
+from __future__ import absolute_import, division, print_function
 
 import collections
 import decimal

--- a/src/canmatrix/formats/xls.py
+++ b/src/canmatrix/formats/xls.py
@@ -23,13 +23,12 @@
 # this script exports xls-files from a canmatrix-object
 # xls-files are the can-matrix-definitions displayed in Excel
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import decimal
 import logging
 import typing
+from builtins import *
 
 import past.builtins
 import xlrd

--- a/src/canmatrix/formats/xls_common.py
+++ b/src/canmatrix/formats/xls_common.py
@@ -19,7 +19,11 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+
 import typing
+from builtins import *
+
 import canmatrix
 
 

--- a/src/canmatrix/formats/xlsx.py
+++ b/src/canmatrix/formats/xlsx.py
@@ -23,12 +23,11 @@
 # this script exports xls-files from a canmatrix-object
 # xls-files are the can-matrix-definitions displayed in Excel
 
-
-from __future__ import absolute_import
-from __future__ import division
+from __future__ import absolute_import, division, print_function
 
 import logging
 import typing
+from builtins import *
 
 import xlsxwriter
 

--- a/src/canmatrix/formats/yaml.py
+++ b/src/canmatrix/formats/yaml.py
@@ -23,8 +23,7 @@
 # yaml-files are just object-dumps human readable.
 # This export is complete, no information lost
 
-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import copy
 import typing

--- a/src/canmatrix/j1939_decoder.py
+++ b/src/canmatrix/j1939_decoder.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+from builtins import *
+
+import attr
+import pathlib2
 
 import canmatrix.formats
-import pathlib2
-import attr
+
 
 @attr.s
 class j1939_decoder(object):

--- a/src/canmatrix/join.py
+++ b/src/canmatrix/join.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import typing
+from builtins import *
 
 import canmatrix
 import canmatrix.formats

--- a/src/canmatrix/log.py
+++ b/src/canmatrix/log.py
@@ -22,7 +22,7 @@
 # Configurable logging
 # Author: Martin Hoffmann (m8ddin@gmail.com)
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import logging
 

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
 import decimal
+
+import pytest
+from builtins import *
 
 import canmatrix.canmatrix
 

--- a/src/canmatrix/tests/test_cli_convert.py
+++ b/src/canmatrix/tests/test_cli_convert.py
@@ -1,7 +1,11 @@
-import pytest
-import pathlib2
+# -*- coding: utf-8 -*-
 import sys
+
+import pathlib2
+import pytest
+
 import canmatrix.formats
+
 pytest_plugins = ["pytester"]
 
 

--- a/src/canmatrix/utils.py
+++ b/src/canmatrix/utils.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import csv
 import shlex
 import sys
 import typing
+from builtins import *
 
 
 def quote_aware_space_split(in_line):  # type: (str) -> typing.List[str]

--- a/test/test.py
+++ b/test/test.py
@@ -1,95 +1,100 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
-
-import sys
-sys.path.append('../src')
-
-import canmatrix.convert
-import canmatrix.formats
 import copy
 import os
 import shutil
 import subprocess
+import sys
+
+sys.path.append('../src')
+import canmatrix.convert
+import canmatrix.formats
+import canmatrix.log
+
 
 if sys.version_info > (3, 2):
     if shutil.which("diff") is None:
-        print ("ERROR: this test needs the tool 'diff' in your path to work")
+        print("ERROR: this test needs the tool 'diff' in your path to work")
         sys.exit()
 
-from canmatrix.log import setup_logger, set_log_level
-logger = setup_logger()
-set_log_level(logger, -1)
+logger = canmatrix.log.setup_logger()
+canmatrix.log.set_log_level(logger, -1)
 
-export_types = []
-import_types = []
 
-for canFormat, features in canmatrix.formats.supportedFormats.items():
-    if "dump" in features:
-        export_types.append(canmatrix.formats.extensionMapping[canFormat])
-    if "load" in features:
-        import_types.append(canmatrix.formats.extensionMapping[canFormat])
+def run_tests():
+    export_types = []
+    import_types = []
 
-# for f in os.listdir('../canmatrix'):
-#    m = re.match('^export(.*).py$', f)
-#    if m is not None and m.group(1) != 'all':
-#        export_types.append(m.group(1))
-#    m = re.match('^import(.*).py$', f)
-#    if m is not None and m.group(1) != 'all' and m.group(1) != 'any':
-#        import_types.append(m.group(1))
+    for canFormat, features in canmatrix.formats.supportedFormats.items():
+        if "dump" in features:
+            export_types.append(canmatrix.formats.extensionMapping[canFormat])
+        if "load" in features:
+            import_types.append(canmatrix.formats.extensionMapping[canFormat])
 
-export_types.sort()
-# TODO: support testing of xlsx
-# export_types.remove('xlsx')
-if "fibex" in export_types:
-    export_types.remove('fibex')
+    # for f in os.listdir('../canmatrix'):
+    #    m = re.match('^export(.*).py$', f)
+    #    if m is not None and m.group(1) != 'all':
+    #        export_types.append(m.group(1))
+    #    m = re.match('^import(.*).py$', f)
+    #    if m is not None and m.group(1) != 'all' and m.group(1) != 'any':
+    #        import_types.append(m.group(1))
 
-import_types.sort()
+    export_types.sort()
+    # TODO: support testing of xlsx
+    # export_types.remove('xlsx')
+    if "fibex" in export_types:
+        export_types.remove('fibex')
 
-test_file_base = 'test'
-converted_path = 'converted'
-try:
-    shutil.rmtree(converted_path)
-except OSError:
-    # it's already not there...
-    pass
+    import_types.sort()
 
-for i in import_types:
-    in_file = test_file_base + '.' + i.lower()
-    if not os.path.isfile(in_file):
-        print('Skipping conversion from missing file ' + in_file)
-    else:
-        to = copy.copy(export_types)
-        try:
-            to.remove(i)
-        except ValueError:
-            # TODO: support testing of xlsx
-            pass
-        print('{} -> {}'.format(i, to))
+    test_file_base = 'test'
+    converted_path = 'converted'
+    try:
+        shutil.rmtree(converted_path)
+    except OSError:
+        # it's already not there...
+        pass
 
-        for t in to:
-            out_file = os.path.basename(test_file_base)
-            # out_file = os.path.splitext(out_file)[0]
-            out_file += '.' + t.lower()
-            directory = os.path.join(converted_path, 'from_' + i)
+    for i in import_types:
+        in_file = test_file_base + '.' + i.lower()
+        if not os.path.isfile(in_file):
+            print('Skipping conversion from missing file ' + in_file)
+        else:
+            to = copy.copy(export_types)
             try:
-                os.makedirs(directory)
-            except OSError:
-                # TODO: be more specific: OSError: [Errno 17] File exists:
-                # 'converted/from_arxml'
+                to.remove(i)
+            except ValueError:
+                # TODO: support testing of xlsx
                 pass
-            out_file = os.path.join(directory, out_file)
-            canmatrix.convert.convert(in_file, out_file)
+            print('{} -> {}'.format(i, to))
 
-exit_code = subprocess.call(['diff', '-r', 'reference', 'converted'])
+            for t in to:
+                out_file = os.path.basename(test_file_base)
+                # out_file = os.path.splitext(out_file)[0]
+                out_file += '.' + t.lower()
+                directory = os.path.join(converted_path, 'from_' + i)
+                try:
+                    os.makedirs(directory)
+                except OSError:
+                    # TODO: be more specific: OSError: [Errno 17] File exists:
+                    # 'converted/from_arxml'
+                    pass
+                out_file = os.path.join(directory, out_file)
+                canmatrix.convert.convert(in_file, out_file)
 
-if exit_code:
-    # difference found
-    message = 'difference found'
-else:
-    # no difference found
-    message = 'no difference'
+    exit_code = subprocess.call(['diff', '-r', 'reference', 'converted'])
 
-print('\n\n    Testing completed: {message}'.format(**locals()))
+    if exit_code:
+        # difference found
+        message = 'difference found'
+    else:
+        # no difference found
+        message = 'no difference'
+
+    print('\n\n    Testing completed: {message}'.format(**locals()))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
- Try to unify imports as described in #236
- Imports from `future` as recommended on [python-future](https://python-future.org/imports.html) pages
- Remove `from module import *` except of future (builtins)

- Let see what buildservers say...im not able to run in on py2