### PR TITLE
Repair more click convert parameters

### DIFF
--- a/requirements.test.py3.txt
+++ b/requirements.test.py3.txt
@@ -2,6 +2,7 @@ atomicwrites==1.1.5
 attrs==18.1.0
 bitstruct==4.0.0
 -e .[test]
+colorama==0.4.1; python_version == '3.4'
 coverage==4.5.1
 future==0.16.0
 more-itertools==4.3.0

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -93,8 +93,8 @@ def get_formats():
 @click.option('--symExportEncoding', 'symExportEncoding', default="iso-8859-1", help="Export charset of sym format, maybe utf-8\ndefault iso-8859-1")
 # xls/csv switches
 @click.option('--xlsMotorolaBitFormat', 'xlsMotorolaBitFormat', default="msbreverse", help="Excel format for startbit of motorola codescharset signals\nValid values: msb, lsb, msbreverse\n default msbreverse")
-@click.option('--additionalFrameAttributes', 'additionalFrameAttributes', default = "", help="append columns to csv/xls(x), example: is_fd")
-@click.option('--additionalSignalAttributes', 'additionalSignalAttributes', default = "", help="append columns to csv/xls(x), example: is_signed,attributes[\"GenSigStartValue\"]")
+@click.option('--additionalFrameAttributes', 'additionalFrameAttributes', default="", help="append columns to csv/xls(x), example: is_fd")
+@click.option('--additionalSignalAttributes', 'additionalSignalAttributes', default="", help="append columns to csv/xls(x), example: is_signed,attributes[\"GenSigStartValue\"]")
 @click.option('--xlsValuesInSeperateLines/--no-xlsValuesInSeperateLines', 'xlsValuesInSeperateLines', default = False, help="Excel format: create seperate line for each value of signal value table\tdefault: False")
 # json switches
 @click.option('--jsonExportCanard/--no-jsonExportCanard', 'jsonExportCanard', default=False, help="Export Canard compatible json format")
@@ -102,7 +102,7 @@ def get_formats():
 @click.option('--jsonMotorolaBitFormat', 'jsonMotorolaBitFormat', default="lsb", help="Json format: startbit of motorola signals\nValid values: msb, lsb, msbreverse\n default lsb")
 @click.option('--jsonNativeTypes/--no-jsonNativeTypes', 'jsonNativeTypes', default=False, help="Uses native json representation for decimals instead of string.")
 #sym switches
-@click.option('--symExportEncoding',    'symExportEncoding', default="iso-8859-1", help="Export charset of sym format, maybe utf-8\ndefault iso-8859-1")
+@click.option('--symExportEncoding', 'symExportEncoding', default="iso-8859-1", help="Export charset of sym format, maybe utf-8\ndefault iso-8859-1")
 # in and out file
 @click.argument('infile', required=True)
 @click.argument('outfile', required=True)

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -98,7 +98,7 @@ def get_formats():
 @click.option('--xlsValuesInSeperateLines/--no-xlsValuesInSeperateLines', 'xlsValuesInSeperateLines', default = False, help="Excel format: create seperate line for each value of signal value table\tdefault: False")
 # json switches
 @click.option('--jsonExportCanard/--no-jsonExportCanard', 'jsonExportCanard', default=False, help="Export Canard compatible json format")
-@click.option('--jsonExportAll/--no-jsonExportAll', 'jsonAll', default=False, help="Export more data to json format")
+@click.option('--jsonExportAll/--no-jsonExportAll', 'jsonExportAll', default=False, help="Export more data to json format")
 @click.option('--jsonMotorolaBitFormat', 'jsonMotorolaBitFormat', default="lsb", help="Json format: startbit of motorola signals\nValid values: msb, lsb, msbreverse\n default lsb")
 @click.option('--jsonNativeTypes/--no-jsonNativeTypes', 'jsonNativeTypes', default=False, help="Uses native json representation for decimals instead of string.")
 #sym switches

--- a/src/canmatrix/formats/csv.py
+++ b/src/canmatrix/formats/csv.py
@@ -116,7 +116,7 @@ def dump(db, file_object, delimiter=',', **options):
         'is signed']
     head_tail = ['Name / Phys. Range', 'Function / Increment Unit', 'Value']
 
-    additional_signal_columns = options.get("additionalAttributes", "").split(",")
+    additional_signal_columns = options.get("additionalSignalAttributes", "").split(",")
     additional_frame_columns = options.get("additionalFrameAttributes", "").split(",")
     motorola_bit_format = options.get("xlsMotorolaBitFormat", "msbreverse")
 

--- a/src/canmatrix/formats/json.py
+++ b/src/canmatrix/formats/json.py
@@ -37,9 +37,9 @@ import canmatrix
 def dump(db, f, **options):
     # type: (canmatrix.CanMatrix, typing.BinaryIO, **str) -> None
 
-    export_canard = options.get('jsonCanard', False)
+    export_canard = options.get('jsonExportCanard', False)
     motorola_bit_format = options.get('jsonMotorolaBitFormat', "lsb")
-    export_all = options.get('jsonAll', False)
+    export_all = options.get('jsonExportAll', False)
     native_types = options.get('jsonNativeTypes', False)
     number_converter = float if native_types else str
     additional_frame_columns = [x for x in options.get("additionalFrameAttributes", "").split(",") if x]

--- a/src/canmatrix/formats/xls.py
+++ b/src/canmatrix/formats/xls.py
@@ -116,8 +116,8 @@ def dump(db, file, **options):
                 ' Signal Not Available', 'Byteorder']
     head_tail = ['Value',   'Name / Phys. Range', 'Function / Increment Unit']
 
-    if len(options.get("additionalAttributes", "")) > 0:
-        additional_signal_columns = options.get("additionalAttributes").split(",")  # type: typing.List[str]
+    if len(options.get("additionalSignalAttributes", "")) > 0:
+        additional_signal_columns = options.get("additionalSignalAttributes").split(",")  # type: typing.List[str]
     else:
         additional_signal_columns = []  # ["attributes['DisplayDecimalPlaces']"]
 

--- a/src/canmatrix/formats/xlsx.py
+++ b/src/canmatrix/formats/xlsx.py
@@ -104,7 +104,7 @@ def dump(db, filename, **options):
     # type: (canmatrix.CanMatrix, str, **str) -> None
     motorola_bit_format = options.get("xlsMotorolaBitFormat", "msbreverse")
     values_in_seperate_lines = options.get("xlsValuesInSeperateLines", True)
-    additional_signal_columns = [x for x in options.get("additionalAttributes", "").split(",") if x]
+    additional_signal_columns = [x for x in options.get("additionalSignalAttributes", "").split(",") if x]
     additional_frame_columns = [x for x in options.get("additionalFrameAttributes", "").split(",") if x]
 
 

--- a/src/canmatrix/tests/test_json.py
+++ b/src/canmatrix/tests/test_json.py
@@ -30,10 +30,10 @@ def default_matrix():
 
 
 def test_export_with_jsonall(default_matrix):
-    """Check the jsonAll doesn't raise and export some additional field."""
+    """Check the jsonExportAll doesn't raise and export some additional field."""
     matrix = default_matrix
     out_file = io.BytesIO()
-    canmatrix.formats.dump(matrix, out_file, "json", jsonAll=True)
+    canmatrix.formats.dump(matrix, out_file, "json", jsonExportAll=True)
     data = out_file.getvalue().decode("utf-8")
     assert "my_value1" in data
     assert "my_value2" in data
@@ -57,7 +57,7 @@ def test_export_long_signal_names():
     frame.add_signal(signal)
 
     out_file = io.BytesIO()
-    canmatrix.formats.dump(matrix, out_file, "json", jsonAll=True)
+    canmatrix.formats.dump(matrix, out_file, "json", jsonExportAll=True)
     data = json.loads(out_file.getvalue().decode("utf-8"))
 
     assert data['messages'][0]['signals'][0]['name'] == long_signal_name
@@ -70,7 +70,7 @@ def test_export_min_max():
     frame.add_signal(signal)
     matrix.add_frame(frame)
     out_file = io.BytesIO()
-    canmatrix.formats.dump(matrix, out_file, "json", jsonAll=True)
+    canmatrix.formats.dump(matrix, out_file, "json", jsonExportAll=True)
     data = json.loads(out_file.getvalue().decode("utf-8"))
     assert(data['messages'][0]['signals'][0]['min'] == '-5')
     assert(data['messages'][0]['signals'][0]['max'] == '42')
@@ -106,7 +106,7 @@ def test_import_min_max():
             }
         ]
     }"""
-    matrix = canmatrix.formats.loads_flat(json_input, "json", jsonAll=True)
+    matrix = canmatrix.formats.loads_flat(json_input, "json", jsonExportAll=True)
     assert matrix.frames[0].signals[0].min == -5
     assert matrix.frames[0].signals[0].max == 42
 
@@ -140,7 +140,7 @@ def test_import_native():
             }
         ]
     }"""
-    matrix = canmatrix.formats.loads_flat(json_input, "json", jsonAll=True)
+    matrix = canmatrix.formats.loads_flat(json_input, "json", jsonExportAll=True)
     assert matrix.frames[0].signals[0].min == -4.2
     assert matrix.frames[0].signals[0].max == 42
     assert matrix.frames[0].signals[0].factor == 0.123
@@ -165,7 +165,7 @@ def test_export_all_native():
     frame.add_signal(signal)
     matrix.add_frame(frame)
     out_file = io.BytesIO()
-    canmatrix.formats.dump(matrix, out_file, "json", jsonAll=True, jsonNativeTypes=True)
+    canmatrix.formats.dump(matrix, out_file, "json", jsonExportAll=True, jsonNativeTypes=True)
     data = json.loads(out_file.getvalue().decode("utf-8"))
     assert (data['messages'][0]['signals'][0]['min'] == -4.2)
     assert (data['messages'][0]['signals'][0]['max'] == 42)


### PR DESCRIPTION
Issue with jsonExportAll (#441) is already fixed, but there are similar issues with jsonExportCanard and additionalSignalAttributes.
I think it's better to pass the full CLI option name to prevent such confusion in the future.
