### PR TITLE
Adding changes to allow ArbitrationId classes to be sorted

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -35,6 +35,7 @@ import logging
 import math
 import struct
 import typing
+import warnings
 from builtins import *
 
 import attr
@@ -580,7 +581,7 @@ def pack_bitstring(length, is_float, value, signed):
     return bitstring
 
 
-@attr.s(cmp=False)
+@attr.s
 class ArbitrationId(object):
     standard_id_mask = ((1 << 11) - 1)
     extended_id_mask = ((1 << 29) - 1)
@@ -593,7 +594,11 @@ class ArbitrationId(object):
         if self.extended is None:
             # Mimicking old behaviour for now -- remove in the future
             self.extended = True
-            logger.warning("Please set 'extended' attribute as a boolean")
+            warnings.warn(
+                "Please set 'extended' attribute as a boolean instead of "
+                "None when creating an instance of ArbitrationId class",
+                DeprecationWarning
+            )
         if self.extended:
             mask = self.extended_id_mask
         else:
@@ -714,37 +719,6 @@ class ArbitrationId(object):
             return self.id | self.compound_extended_mask
         else:
             return self.id
-
-    def __eq__(self, other):  # type: (ArbitrationId) -> ArbitrationId
-        return self.id == other.id and self.extended == other.extended
-
-    def __le__(self, other):
-        if not self.extended and other.extended:
-            return True
-        if self.extended and not other.extended:
-            return False
-        return self.id <= other.id
-
-    def __lt__(self, other):
-        if not self.extended and other.extended:
-            return True
-        if self.extended and not other.extended:
-            return False
-        return self.id < other.id
-
-    def __ge__(self, other):
-        if not self.extended and other.extended:
-            return False
-        if self.extended and not other.extended:
-            return True
-        return self.id >= other.id
-
-    def __gt__(self, other):
-        if not self.extended and other.extended:
-            return False
-        if self.extended and not other.extended:
-            return True
-        return self.id > other.id
 
 
 @attr.s(cmp=False)

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -711,7 +711,7 @@ class ArbitrationId(object):
         else:
             return self.id
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # type: (ArbitrationId) -> ArbitrationId
         return (
             self.id == other.id
             and (
@@ -720,6 +720,34 @@ class ArbitrationId(object):
                 or self.extended == other.extended
             )
         )
+
+    def __le__(self, other):
+        if not self.extended and other.extended:
+            return True
+        if self.extended and not other.extended:
+            return False
+        return self.id <= other.id
+
+    def __lt__(self, other):
+        if not self.extended and other.extended:
+            return True
+        if self.extended and not other.extended:
+            return False
+        return self.id < other.id
+
+    def __ge__(self, other):
+        if not self.extended and other.extended:
+            return False
+        if self.extended and not other.extended:
+            return True
+        return self.id >= other.id
+
+    def __gt__(self, other):
+        if not self.extended and other.extended:
+            return False
+        if self.extended and not other.extended:
+            return True
+        return self.id > other.id
 
 
 @attr.s(cmp=False)

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -587,10 +587,14 @@ class ArbitrationId(object):
     compound_extended_mask = (1 << 31)
 
     id = attr.ib(default=None)
-    extended = attr.ib(default=None)
+    extended = attr.ib(default=False)  # type: bool
 
     def __attrs_post_init__(self):
-        if self.extended is None or self.extended:
+        if self.extended is None:
+            # Mimicking old behaviour for now -- remove in the future
+            self.extended = True
+            logger.warning("Please set 'extended' attribute as a boolean")
+        if self.extended:
             mask = self.extended_id_mask
         else:
             mask = self.standard_id_mask
@@ -712,14 +716,7 @@ class ArbitrationId(object):
             return self.id
 
     def __eq__(self, other):  # type: (ArbitrationId) -> ArbitrationId
-        return (
-            self.id == other.id
-            and (
-                self.extended is None
-                or other.extended is None
-                or self.extended == other.extended
-            )
-        )
+        return self.id == other.id and self.extended == other.extended
 
     def __le__(self, other):
         if not self.extended and other.extended:

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -811,7 +811,7 @@ def test_decoded_signal_named_value():
 def test_Arbitration_id():
     id_standard = canmatrix.ArbitrationId(id=0x1, extended=False)
     id_extended = canmatrix.ArbitrationId(id=0x1, extended=True)
-    id_unknown = canmatrix.ArbitrationId(id=0x1, extended=None)
+    id_unknown = canmatrix.ArbitrationId(id=0x1, extended=None)  # Defaults to True
 
     id_from_int_standard = canmatrix.ArbitrationId.from_compound_integer(1)
     id_from_int_extended = canmatrix.ArbitrationId.from_compound_integer(1 | 1 << 31)
@@ -823,7 +823,7 @@ def test_Arbitration_id():
     assert id_extended.id == 1
     assert id_unknown.id == 1
     assert id_standard != id_extended
-    assert id_standard == id_unknown
+    assert id_standard != id_unknown
     assert id_extended == id_unknown
     assert id_from_int_standard == id_standard
     assert id_from_int_standard != id_extended
@@ -847,6 +847,20 @@ def test_arbitration_id_j1939_direct_setters():
     assert arb_id.pgn == 0xF1AA
     assert arb_id.j1939_source == 0x22
     assert arb_id.j1939_priority == 3
+
+def test_arbitration_id_comparators():
+    id_standard_1 = canmatrix.ArbitrationId(id=0x1, extended=False)
+    id_standard_2 = canmatrix.ArbitrationId(id=0x2, extended=False)
+    id_extended_1 = canmatrix.ArbitrationId(id=0x1, extended=True)
+    id_extended_2 = canmatrix.ArbitrationId(id=0x2, extended=True)
+
+    assert id_extended_1 > id_standard_2
+    sorting_results = sorted((
+        id_extended_1, id_standard_2, id_extended_2, id_standard_1))
+    assert sorting_results[0] == id_standard_1
+    assert sorting_results[1] == id_standard_2
+    assert sorting_results[2] == id_extended_1
+    assert sorting_results[3] == id_extended_2
 
 @pytest.fixture
 def empty_matrix():

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -854,12 +854,11 @@ def test_arbitration_id_comparators():
     id_extended_1 = canmatrix.ArbitrationId(id=0x1, extended=True)
     id_extended_2 = canmatrix.ArbitrationId(id=0x2, extended=True)
 
-    assert id_extended_1 > id_standard_2
     sorting_results = sorted((
         id_extended_1, id_standard_2, id_extended_2, id_standard_1))
     assert sorting_results[0] == id_standard_1
-    assert sorting_results[1] == id_standard_2
-    assert sorting_results[2] == id_extended_1
+    assert sorting_results[1] == id_extended_1
+    assert sorting_results[2] == id_standard_2
     assert sorting_results[3] == id_extended_2
 
 @pytest.fixture


### PR DESCRIPTION
Changed default arbitration_id.extended to False from None
Removed the existing equals method and using attr.s default comparison methods
The current logic implemented is that:
 ArbitrationId(id=0x1, extended=False) <   ArbitrationId(id=0x1, extended=True)
 ArbitrationId(id=0x1, extended=True) < ArbitrationId(id=0x2, extended=False)
