### PR TITLE
#459: Log the exception as well when importing a format failed

### DIFF
--- a/src/canmatrix/formats/__init__.py
+++ b/src/canmatrix/formats/__init__.py
@@ -27,7 +27,7 @@ for module in moduleList:
         importlib.import_module("canmatrix.formats." + module)
         loadedFormats.append(module)
     except ImportError:
-        logger.info("%s is not supported", module)
+        logger.exception("%s is not supported", module)
 
 for loadedModule in loadedFormats:
     supportedFormats[loadedModule] = []


### PR DESCRIPTION
As mentioned in the ticket itself, this alters the _level_ the message is logged to: instead of logging to `INFO`, it is now logged as `ERROR`. 
