### PR TITLE
Check for EOF when parsing enums in a .sym file. Fixes #465

### DIFF
--- a/src/canmatrix/formats/sym.py
+++ b/src/canmatrix/formats/sym.py
@@ -354,9 +354,12 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
                     while not line[5:].strip().endswith(')'):
                         line = line.split('//')[0]
                         if sys.version_info > (3, 0):  # is there a clean way to to it?
-                            line += ' ' + f.readline().decode(sym_import_encoding).strip()
+                            next_line = f.readline().decode(sym_import_encoding)
                         else:
-                            line += ' ' + next(f).decode(sym_import_encoding).strip()
+                            next_line = next(f).decode(sym_import_encoding)
+                        if next_line is "":
+                            raise EOFError("Reached EOF before finding terminator for enum :\"{}\"".format(line))
+                        line += next_line.strip()
                     line = line.split('//')[0]
                     temp_array = line[5:].strip().rstrip(')').split('(', 1)
                     val_table_name = temp_array[0]

--- a/src/canmatrix/tests/test_sym.py
+++ b/src/canmatrix/tests/test_sym.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import io
+import sys
 import textwrap
 
 import pytest
@@ -167,6 +168,8 @@ def test_unterminated_enum():
     matrix = canmatrix.formats.sym.load(f)
 
     assert len(matrix.load_errors) == 1
-
-    assert isinstance(matrix.load_errors[0], EOFError)
+    if sys.version_info > (3, 0):
+        assert isinstance(matrix.load_errors[0], EOFError)
+    else:
+        assert isinstance(matrix.load_errors[0], StopIteration)
 


### PR DESCRIPTION
I have added a fix for #465 and a new test case in test_sym.py that checks for an EOFError in the case of an untemrinated enum.