### PR TITLE
Fix additional case in sym enum export

### DIFF
--- a/src/canmatrix/formats/sym.py
+++ b/src/canmatrix/formats/sym.py
@@ -302,6 +302,7 @@ Title=\"{}\"
                         for signal in frame.signals:
                             if signal.multiplex == i or signal.multiplex is None:
                                 mux_out += create_signal(db, signal)
+                                enum_dict.update(create_enum_from_signal_values(signal))
                         output += mux_out + "\n"
 
             else:

--- a/src/canmatrix/formats/sym.py
+++ b/src/canmatrix/formats/sym.py
@@ -440,6 +440,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
 
                     is_float = False
                     is_ascii = False
+                    enumeration = None
                     if index_offset != 1:
                         is_signed = True
                     else:
@@ -459,7 +460,8 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
                             is_float = True
                         elif type_label in ['char', 'string']:
                             is_ascii = True
-                            pass
+                        elif type_label in db.value_tables.keys():
+                            enumeration = type_label
                         else:
                             raise ValueError('Unknown type \'{}\' found'.format(type_label))
 
@@ -582,6 +584,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
                             multiplex=multiplexor,
                             comment=comment,
                             type_label=type_label,
+                            enumeration=enumeration,
                             **extras)
                         if min_value is not None:
                             signal.min = float_factory(min_value)

--- a/src/canmatrix/tests/test_sym.py
+++ b/src/canmatrix/tests/test_sym.py
@@ -288,8 +288,8 @@ Var=Char char 1,8
 Var=String string 16,16
 Var=Signed signed 32,4
 Var=Unsigned unsigned 36,4
-'''  # Var=Enum EnumAnimals 40,4
-                   '''
+Var=Enum EnumAnimals 40,4
+
 Var=Raw raw 48,16
 
 [SymbolDouble]
@@ -348,6 +348,7 @@ Var=Float float 0,32	// Must be 4 Bytes according to PCAN Symbol Editor V5
                                                             "String",
                                                             "Signed",
                                                             "Unsigned",
+                                                            "Enum",
                                                             "Raw",
                                                             "Double",
                                                             "Float", ])


### PR DESCRIPTION
Fixes an oversight in my previous fix for #480 
Add the values from signals which are in multiplexed frames as well.