### PR TITLE
Log missing format module import as warning instead of exception

### DIFF
--- a/src/canmatrix/formats/__init__.py
+++ b/src/canmatrix/formats/__init__.py
@@ -27,7 +27,7 @@ for module in moduleList:
         importlib.import_module("canmatrix.formats." + module)
         loadedFormats.append(module)
     except ImportError:
-        logger.exception("%s is not supported", module)
+        logger.warning("%s is not supported", module)
 
 for loadedModule in loadedFormats:
     supportedFormats[loadedModule] = []


### PR DESCRIPTION
## Description

Logging as exception prints a stack backtrace. Since the modules are optional and listed as extra instead of a required dependency, this should probably be a warning instead of an error/exception.

## Reproduce
Just run the tests included in this module, without installing additional modules (such as `xlsxwriter`):
```
pip3 install canmatrix

python3 test/test.py
```

### Before:
```
arxml is not supported
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/__init__.py", line 27, in <module>
    importlib.import_module("canmatrix.formats." + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/arxml.py", line 34, in <module>
    import lxml.etree
ModuleNotFoundError: No module named 'lxml'
kcd is not supported
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/__init__.py", line 27, in <module>
    importlib.import_module("canmatrix.formats." + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/kcd.py", line 35, in <module>
    import lxml.etree
ModuleNotFoundError: No module named 'lxml'
fibex is not supported
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/__init__.py", line 27, in <module>
    importlib.import_module("canmatrix.formats." + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/fibex.py", line 33, in <module>
    import lxml.etree
ModuleNotFoundError: No module named 'lxml'
xls is not supported
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/__init__.py", line 27, in <module>
    importlib.import_module("canmatrix.formats." + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/xls.py", line 34, in <module>
    import xlrd
ModuleNotFoundError: No module named 'xlrd'
xlsx is not supported
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/__init__.py", line 27, in <module>
    importlib.import_module("canmatrix.formats." + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/user/.local/lib/python3.8/site-packages/canmatrix/formats/xlsx.py", line 32, in <module>
    import xlsxwriter
ModuleNotFoundError: No module named 'xlsxwriter'
```

### After:
```
arxml is not supported
kcd is not supported
fibex is not supported
xls is not supported
xlsx is not supported
```

