### PR TITLE
add is_fd flag for json output

### DIFF
--- a/src/canmatrix/formats/json.py
+++ b/src/canmatrix/formats/json.py
@@ -93,6 +93,7 @@ def dump(db, f, **options):
             symbolic_frame = {"name": frame.name,
                               "id": int(frame.arbitration_id.id),
                               "is_extended_frame": frame.arbitration_id.extended,
+                              "is_fd": frame.is_fd,
                               "signals": symbolic_signals}
             frame_attributes = {
                 attr: frame.attribute(attr)
@@ -146,6 +147,7 @@ def dump(db, f, **options):
                 {"name": frame.name,
                  "id": int(frame.arbitration_id.id),
                  "is_extended_frame": frame.arbitration_id.extended,
+                 "is_fd": frame.is_fd,
                  "signals": symbolic_signals,
                  "attributes": frame_attributes,
                  "comment": frame.comment,

--- a/src/canmatrix/tests/test_json.py
+++ b/src/canmatrix/tests/test_json.py
@@ -88,6 +88,7 @@ def test_import_min_max():
                 "comment": "",
                 "id": 10,
                 "is_extended_frame": false,
+                "is_fd": false,
                 "length": 6,
                 "name": "test_frame",
                 "signals": [
@@ -122,6 +123,7 @@ def test_import_native():
                 "comment": "",
                 "id": 10,
                 "is_extended_frame": false,
+                "is_fd": false,
                 "length": 6,
                 "name": "test_frame",
                 "signals": [
@@ -167,6 +169,7 @@ def test_import_export_enums():
                 "comment": "",
                 "id": 10,
                 "is_extended_frame": false,
+                "is_fd": false,
                 "length": 6,
                 "name": "test_frame",
                 "signals": [
@@ -218,3 +221,4 @@ def test_export_all_native():
     assert (data['messages'][0]['signals'][0]['max'] == 42)
     assert (data['messages'][0]['signals'][0]['factor'] == 0.123)
     assert (data['messages'][0]['signals'][0]['offset'] == 1)
+    assert (data['messages'][0]['is_fd'] is False)


### PR DESCRIPTION
fd flag is implemented but not used in json.
add is_fd flag to the json exporter.