### PR TITLE
fix issue #547

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrs>=18.1.0
+attrs>=19.2.0
 click
 enum34; python_version < '3.4'
 future

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 """
 
 from setuptools import find_packages, setup
@@ -77,7 +79,7 @@ setup(
     license = "BSD",
     platforms = ["any"],
     install_requires = [
-        "attrs>=18.1.0",
+        "attrs>=19.2.0",
         "click",
         "enum34; python_version < '3.4'",
         "future",

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -121,7 +121,7 @@ def normalize_value_table(table):  # type: (typing.Mapping) -> typing.MutableMap
     return {int(k): v for k, v in table.items()}
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Signal(object):
     """
     Represents a Signal in CAN Matrix.
@@ -449,7 +449,7 @@ class Signal(object):
         return self.name
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SignalGroup(object):
     """
     Represents signal-group, containing multiple Signals.
@@ -746,7 +746,7 @@ class ArbitrationId(object):
             )
         )
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Pdu(object):
     """
     Represents a PDU.
@@ -814,7 +814,7 @@ class Pdu(object):
         return None
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Frame(object):
     """
     Represents CAN Frame.
@@ -1519,7 +1519,7 @@ class matrix_class(enum.Enum):
     FLEXRAY = 2
     SOMEIP = 3
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class CanMatrix(object):
     """
     The Can-Matrix-Object


### PR DESCRIPTION
DeprecationWarning: The usage of `cmp` is deprecated and will be removed
on or after 2021-06-01.  Please use `eq` and `order` instead.
    @attr.s(cmp=False)

Signed-off-by: An Nguyen <phucan.nguyen@daum.net>