### PR TITLE
fix issue #559

### DIFF
--- a/src/canmatrix/compare.py
+++ b/src/canmatrix/compare.py
@@ -73,8 +73,11 @@ def compare_db(db1, db2, ignore=None):
     for f1 in db1.frames:
         f2 = db2.frame_by_name(f1.name)
         f2id = db2.frame_by_id(f1.arbitration_id)
-        if f2id is None and f2 is None:
-            result.add_child(CompareResult("deleted", "FRAME", f1))
+        if f2 is None:
+            if f2id is None:
+                result.add_child(CompareResult("deleted", "FRAME", f1))
+            else:
+                result.add_child(compare_frame(f1, f2id, ignore))
         else:
             result.add_child(compare_frame(f1, f2, ignore))
     for f2 in db2.frames:
@@ -312,6 +315,13 @@ def compare_frame(f1, f2, ignore=None):
                     "dlc: %d" %
                     f1.size, "dlc: %d" %
                     f2.size]))
+    if f1.arbitration_id.id != f2.arbitration_id.id:
+        result.add_child(
+            CompareResult(
+                "changed", "ID", f1, [
+                    "ID: %xh" %
+                    f1.arbitration_id.id, "ID: %xh" %
+                    f2.arbitration_id.id]))
     if f1.arbitration_id.extended != f2.arbitration_id.extended:
         result.add_child(
             CompareResult(


### PR DESCRIPTION
If the frame has same ID but different name, it should get data from frame_by_id() instead of frame_by_name() for comparison.