### PR TITLE
fix initial value setting

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -405,6 +405,8 @@ class Signal(object):
         """
         if value is None:
             value = self.initial_value
+            if not (self.min <= value <= self.max):
+                value = self.min
 
         if isinstance(value, basestring):
             for value_key, value_string in self.values.items():

--- a/src/canmatrix/tests/test_canmatrix.py
+++ b/src/canmatrix/tests/test_canmatrix.py
@@ -49,7 +49,7 @@ def test_encode_signal():
     assert s5.phys2raw(s5.min) == -128
 
     s6 = canmatrix.canmatrix.Signal('signal', size=8, is_signed=False, offset=5)
-    assert s6.phys2raw() == -5
+    assert s6.phys2raw() == 0
     assert s6.phys2raw(10) == 5
     assert s6.phys2raw(s6.max) == 255
     assert s6.phys2raw(s6.min) == 0


### PR DESCRIPTION
use min value when initial_value default value is out of range [min, max]