### PR TITLE
[arxml]: canmatrix.Signal names rework

### DIFF
--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -398,8 +398,11 @@ def dump(in_db, f, **options):
                 name = output_names[frame][signal]
                 if isinstance(val, float):
                     val = format_float(val)
-                f.write(create_attribute_string(attrib, "SG_", '%d ' % frame.arbitration_id.to_compound_integer() + name, val,
-                                                db.signal_defines[attrib].type == "STRING").encode(dbc_export_encoding, ignore_encoding_errors))
+                if attrib in db.signal_defines:
+                    f.write(create_attribute_string(
+                        attrib, "SG_", '%d ' % frame.arbitration_id.to_compound_integer() + name, val,
+                        db.signal_defines[attrib].type == "STRING").encode(dbc_export_encoding, ignore_encoding_errors)
+                    )
 
     f.write("\n".encode(dbc_export_encoding, ignore_encoding_errors))
 

--- a/src/canmatrix/tests/test_arxml.py
+++ b/src/canmatrix/tests/test_arxml.py
@@ -9,7 +9,7 @@ except ImportError:
 
 def test_ecu_extract():
     here = Path(__file__).parent
-    
+
     db = canmatrix.formats.arxml.load(str(here / "MyECU.ecuc.arxml"))['']
     assert db.frames is not None
     assert len(db.frames) == 2
@@ -22,8 +22,10 @@ def test_get_signals_from_container_i_pdu():
     matrix = canmatrix.formats.arxml.load(str(here / "ARXMLContainerTest.arxml"))
     assert matrix["New_CanCluster"].frames[0].signals[0].name == 'Header_ID'
     assert matrix["New_CanCluster"].frames[0].signals[1].name == 'Header_DLC'
-    assert matrix["New_CanCluster"].frames[0].signals[2].name == 'PDU_Contained_1_Signal1_905db81da40081cb'
-    assert matrix["New_CanCluster"].frames[0].signalGroups[0].signals[0].name == 'PDU_Contained_1_Signal1_905db81da40081cb'
+    assert matrix["New_CanCluster"].frames[0].signals[2].name == 'PDU_Contained_1_Signal1'
+    assert matrix["New_CanCluster"].frames[0].signalGroups[0].signals[0].name == 'PDU_Contained_1_Signal1'
+    assert matrix["New_CanCluster"].frames[0].signals[2].attributes["ShortName"] == 'PDU_Contained_1_Signal1_905db81da40081cb'
+    assert matrix["New_CanCluster"].frames[0].signalGroups[0].signals[0].attributes["ShortName"] == 'PDU_Contained_1_Signal1_905db81da40081cb'
 
 def test_get_signals_from_secured_pdu():
     here = Path(__file__).parent


### PR DESCRIPTION
Hello,

Using iSignalName for signal naming in arxml parser
I think this is aligned with Vector

added new attributes for signal names (ShortName, compuName), so if any other user have preference for naming (my personal preference is the compu method name)

I think older versions of canmatrix used the compu name, so I may be wrong with this PR

thanks