### PR TITLE
bugfix: no signals available for a pdu

### DIFF
--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -230,18 +230,21 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
             db.recalc_dlc(options['recalcDLC'])
 
         # PDU contained frames handling
+        frame_pdu_container_list = [
+            frame
+            for frame in db.frames
+            if frame.is_pdu_container
+        ]
         if options.get('ignorePduContainer'):
-            for frame in db:
-                if frame.is_pdu_container:
-                    db.del_frame(frame)
+            for frame in frame_pdu_container_list:
+                db.del_frame(frame)
         else:
             # convert PDU contained frames to multiplexed frame
-            for frame in db:
-                if frame.is_pdu_container:
-                    logger.warning("%s converted to Multiplexed frame", frame.name)
-                    new_frame = convert_pdu_container_to_multiplexed(frame)
-                    db.del_frame(frame)
-                    db.add_frame(new_frame)
+            for frame in frame_pdu_container_list:
+                logger.warning("%s converted to Multiplexed frame", frame.name)
+                new_frame = convert_pdu_container_to_multiplexed(frame)
+                db.del_frame(frame)
+                db.add_frame(new_frame)
 
         if options.get('signalNameFromAttrib') is not None:
             for signal in [b for a in db for b in a.signals]:

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1021,7 +1021,7 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
             if isignal is not None:
                 logger.debug("get_signals: found I-SIGNAL-GROUP ")
 
-                isignal_array = ea.follow_ref(isignal, "I-SIGNAL-REF")
+                isignal_array = ea.follow_all_ref(isignal, "I-SIGNAL-REF")
 
                 system_signal_array = [ea.follow_ref(isignal, "SYSTEM-SIGNAL-REF") for isignal in isignal_array]
                 system_signal_group = ea.follow_ref(isignal, "SYSTEM-SIGNAL-GROUP-REF")

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1115,7 +1115,8 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
                     logger.debug('No valid compu method found for this - check ARXML file!!')
                     compu_method = None
         if compu_method is None:
-            logger.error('No valid compu method found for this - check ARXML file!!')
+            logger.error('No valid compu method found for isignal/systemsignal {}/{} - check ARXML file!!'
+                         .format(ea.get_short_name(isignal), ea.get_short_name(system_signal)))
         #####################################################################################################
         # no found compu-method fuzzy search in systemsignal:
         #####################################################################################################
@@ -1341,8 +1342,10 @@ def get_frame_from_container_ipdu(pdu, target_frame, ea, float_factory, headers_
             header_id = int(header_id, 0)
 
         if ipdu is not None and 'SECURED-I-PDU' in ipdu.tag:
+            secured_i_pdu_name = ea.get_element_name(ipdu)
             payload = ea.follow_ref(ipdu, "PAYLOAD-REF")
             ipdu = ea.follow_ref(payload, "I-PDU-REF")
+            logger.info("found secured pdu '%s', dissolved to '%s'", secured_i_pdu_name, ea.get_element_name(ipdu))
         try:
             offset = int(ea.get_child(ipdu, "OFFSET").text) * 8
         except:
@@ -1428,9 +1431,10 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
         pdu = ea.follow_ref(frame_elem, "PDU-REF")  # SIGNAL-I-PDU
 
         if pdu is not None and 'SECURED-I-PDU' in pdu.tag:
+            secured_i_pdu_name = ea.get_element_name(pdu)
             payload = ea.follow_ref(pdu, "PAYLOAD-REF")
             pdu = ea.follow_ref(payload, "I-PDU-REF")
-            # logger.info("found secured pdu - no signal extraction possible: %s", get_element_name(pdu, ns))
+            logger.info("found secured pdu '%s', dissolved to '%s'", secured_i_pdu_name, ea.get_element_name(pdu))
 
         pdu_frame_mapping[pdu] = ea.get_element_name(frame_elem)
 
@@ -1453,7 +1457,7 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
     if pdu is None:
         logger.error("pdu is None")
     else:
-        logger.debug(ea.get_element_name(pdu))
+        logger.debug("PDU: " + ea.get_element_name(pdu))
 
     if new_frame.comment is None:
         new_frame.add_comment(ea.get_element_desc(pdu))
@@ -1525,7 +1529,8 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
     if new_frame.is_pdu_container and new_frame.cycle_time == 0:
         cycle_times = {pdu.cycle_time for pdu in new_frame.pdus}
         if len(cycle_times) > 1:
-            logger.warning("%s is contained pdu frame with different cycle times", new_frame.cycle_time)
+            logger.warning("%s is pdu-container(frame) with different cycle times (%s), frame cycle-time: %s",
+                           new_frame.name, cycle_times, new_frame.cycle_time)
         new_frame.cycle_time = min(cycle_times)
     new_frame.fit_dlc()
     if frame_elem is not None:


### PR DESCRIPTION
the list of signals (inside the PDUs) are always empty.
to get the signals for a pdu you have to use follow_all_ref instead of follow_ref