### PR TITLE
arxml: read data related to E2E-protection

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -49,7 +49,8 @@ import canmatrix.utils
 if attr.__version__ < '17.4.0':  # type: ignore
     raise RuntimeError("need attrs >= 17.4.0")
 logger = logging.getLogger(__name__)
-defaultFloatFactory = decimal.Decimal  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
+# defaultFloatFactory = decimal.Decimal  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
+defaultFloatFactory = float  # HoPHiL: use float for the moment. because msgpack cant serialize decimal
 
 
 class ExceptionTemplate(Exception):

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -466,6 +466,7 @@ class SignalGroup(object):
     name = attr.ib()  # type: str
     id = attr.ib()  # type: int
     signals = attr.ib(factory=list, repr=False)  # type: typing.MutableSequence[Signal]
+    e2e_trans = attr.ib(default=None)
 
     def add_signal(self, signal):  # type: (Signal) -> None
         """Add a Signal to SignalGroup.
@@ -997,7 +998,7 @@ class Frame(object):
 
         return iter(self.signals)
 
-    def add_signal_group(self, Name, Id, signalNames):
+    def add_signal_group(self, Name, Id, signalNames, e2e_trans=None):
         # type: (str, int, typing.Sequence[str]) -> None
         """Add new SignalGroup to the Frame. Add given signals to the group.
 
@@ -1005,7 +1006,7 @@ class Frame(object):
         :param int Id: Group id
         :param list of str signalNames: list of Signal names to add. Non existing names are ignored.
         """
-        newGroup = SignalGroup(Name, Id)
+        newGroup = SignalGroup(Name, Id, e2e_trans=e2e_trans)
         self.signalGroups.append(newGroup)
         for signal in signalNames:
             signal = signal.strip()

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -230,18 +230,21 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
             db.recalc_dlc(options['recalcDLC'])
 
         # PDU contained frames handling
+        frame_pdu_container_list = [
+            frame
+            for frame in db.frames
+            if frame.is_pdu_container
+        ]
         if options.get('ignorePduContainer'):
-            for frame in db:
-                if frame.is_pdu_container:
-                    db.del_frame(frame)
+            for frame in frame_pdu_container_list:
+                db.del_frame(frame)
         else:
             # convert PDU contained frames to multiplexed frame
-            for frame in db:
-                if frame.is_pdu_container:
-                    logger.warning("%s converted to Multiplexed frame", frame.name)
-                    new_frame = convert_pdu_container_to_multiplexed(frame)
-                    db.del_frame(frame)
-                    db.add_frame(new_frame)
+            for frame in frame_pdu_container_list:
+                logger.warning("%s converted to Multiplexed frame", frame.name)
+                new_frame = convert_pdu_container_to_multiplexed(frame)
+                db.del_frame(frame)
+                db.add_frame(new_frame)
 
         if options.get('signalNameFromAttrib') is not None:
             for signal in [b for a in db for b in a.signals]:

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1021,7 +1021,7 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
             if isignal is not None:
                 logger.debug("get_signals: found I-SIGNAL-GROUP ")
 
-                isignal_array = ea.follow_ref(isignal, "I-SIGNAL-REF")
+                isignal_array = ea.follow_all_ref(isignal, "I-SIGNAL-REF")
 
                 system_signal_array = [ea.follow_ref(isignal, "SYSTEM-SIGNAL-REF") for isignal in isignal_array]
                 system_signal_group = ea.follow_ref(isignal, "SYSTEM-SIGNAL-GROUP-REF")

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -39,7 +39,8 @@ import canmatrix.types
 import canmatrix.utils
 
 logger = logging.getLogger(__name__)
-default_float_factory = decimal.Decimal
+# default_float_factory = decimal.Decimal
+default_float_factory = float  # HoPHiL: use float for the moment. because msgpack cant serialize decimal
 
 clusterExporter = 1
 clusterImporter = 1

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1115,7 +1115,8 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
                     logger.debug('No valid compu method found for this - check ARXML file!!')
                     compu_method = None
         if compu_method is None:
-            logger.error('No valid compu method found for this - check ARXML file!!')
+            logger.error('No valid compu method found for isignal/systemsignal {}/{} - check ARXML file!!'
+                         .format(ea.get_short_name(isignal), ea.get_short_name(system_signal)))
         #####################################################################################################
         # no found compu-method fuzzy search in systemsignal:
         #####################################################################################################
@@ -1341,8 +1342,10 @@ def get_frame_from_container_ipdu(pdu, target_frame, ea, float_factory, headers_
             header_id = int(header_id, 0)
 
         if ipdu is not None and 'SECURED-I-PDU' in ipdu.tag:
+            secured_i_pdu_name = ea.get_element_name(ipdu)
             payload = ea.follow_ref(ipdu, "PAYLOAD-REF")
             ipdu = ea.follow_ref(payload, "I-PDU-REF")
+            logger.info("found secured pdu '%s', dissolved to '%s'", secured_i_pdu_name, ea.get_element_name(ipdu))
         try:
             offset = int(ea.get_child(ipdu, "OFFSET").text) * 8
         except:
@@ -1428,9 +1431,10 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
         pdu = ea.follow_ref(frame_elem, "PDU-REF")  # SIGNAL-I-PDU
 
         if pdu is not None and 'SECURED-I-PDU' in pdu.tag:
+            secured_i_pdu_name = ea.get_element_name(pdu)
             payload = ea.follow_ref(pdu, "PAYLOAD-REF")
             pdu = ea.follow_ref(payload, "I-PDU-REF")
-            # logger.info("found secured pdu - no signal extraction possible: %s", get_element_name(pdu, ns))
+            logger.info("found secured pdu '%s', dissolved to '%s'", secured_i_pdu_name, ea.get_element_name(pdu))
 
         pdu_frame_mapping[pdu] = ea.get_element_name(frame_elem)
 
@@ -1453,7 +1457,7 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
     if pdu is None:
         logger.error("pdu is None")
     else:
-        logger.debug(ea.get_element_name(pdu))
+        logger.debug("PDU: " + ea.get_element_name(pdu))
 
     if new_frame.comment is None:
         new_frame.add_comment(ea.get_element_desc(pdu))
@@ -1525,7 +1529,8 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
     if new_frame.is_pdu_container and new_frame.cycle_time == 0:
         cycle_times = {pdu.cycle_time for pdu in new_frame.pdus}
         if len(cycle_times) > 1:
-            logger.warning("%s is contained pdu frame with different cycle times", new_frame.cycle_time)
+            logger.warning("%s is pdu-container(frame) with different cycle times (%s), frame cycle-time: %s",
+                           new_frame.name, cycle_times, new_frame.cycle_time)
         new_frame.cycle_time = min(cycle_times)
     new_frame.fit_dlc()
     if frame_elem is not None:

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -907,10 +907,22 @@ signal_rxs = {}  # type: typing.Dict[_Element, typing.List[str]]
 frames_cache = {}  # type: typing.Dict[_Element, canmatrix.Frame]
 
 
-def get_sys_signals(sys_signal, sys_signal_array, frame, group_id, ea):
+def get_signalgrp_and_signals(sys_signal, sys_signal_array, frame, group_id, ea):
     # type: (_Element, typing.Sequence[_Element], canmatrix.Frame, int, str) -> None
     members = [ea.get_element_name(signal) for signal in sys_signal_array]
-    frame.add_signal_group(ea.get_element_name(sys_signal), group_id, members)
+
+    # get data related to E2E-Protection
+    transform_ele = ea.follow_ref(sys_signal, "TRANSFORMER-REF")
+    e2e_transform = None
+    if transform_ele is not None:
+        e2e_transform = {
+            'profile': ea.get_child(transform_ele, "PROFILE-NAME").text,
+        }
+        data_id_elems = ea.get_children(ea.get_child(sys_signal, "TRANSFORMATION-I-SIGNAL-PROPSS"), "DATA-ID")
+        if data_id_elems is not None:
+            e2e_transform['data_ids'] = [int(x.text) for x in data_id_elems]
+
+    frame.add_signal_group(ea.get_element_name(sys_signal), group_id, members, e2e_transform)
 
 
 def decode_compu_method(compu_method, ea, float_factory):
@@ -1021,12 +1033,8 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
             isignal = ea.follow_ref(signal, "I-SIGNAL-GROUP-REF")
             if isignal is not None:
                 logger.debug("get_signals: found I-SIGNAL-GROUP ")
-
                 isignal_array = ea.follow_all_ref(isignal, "I-SIGNAL-REF")
-
-                system_signal_array = [ea.follow_ref(isignal, "SYSTEM-SIGNAL-REF") for isignal in isignal_array]
-                system_signal_group = ea.follow_ref(isignal, "SYSTEM-SIGNAL-GROUP-REF")
-                get_sys_signals(system_signal_group, system_signal_array, frame, group_id, ea)
+                get_signalgrp_and_signals(isignal, isignal_array, frame, group_id, ea)
                 group_id = group_id + 1
                 continue
         if isignal is None:
@@ -1053,7 +1061,7 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
 
         if system_signal is not None and "SYSTEM-SIGNAL-GROUP" in system_signal.tag:
             system_signals = ea.find_children_by_path(system_signal, "SYSTEM-SIGNAL-REFS/SYSTEM-SIGNAL")
-            get_sys_signals(system_signal, system_signals, frame, group_id, ea)
+            get_signalgrp_and_signals(system_signal, system_signals, frame, group_id, ea)
 
             group_id = group_id + 1
             continue

--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 
 
 def default_float_factory(value):  # type: (typing.Any) -> decimal.Decimal
-    return decimal.Decimal(value)
+    # return decimal.Decimal(value)
+    return float(value)  # HoPHiL: use float for the moment. because msgpack cant serialize decimal
 
 
 def normalize_name(name, whitespace_replacement):  # type: (str, str) -> str


### PR DESCRIPTION
in arxml there are informations stored how the End2End-Protection need to be done, which is needed to transmitt and receive E2E-protected Signalgroups.

so i added a basic implementation to read some basic informations, until now the E2E-Profile and the data-ids which are needed during calculation of the E2E-protection.

this informations stored at the I-SignalGroup, but until now even if i I-Signalgroup was found, the System-Signal-Group was searched and used.
I changed it in the way that if the I-Singalgroup was found also this Signalgroup will be used (and renamed the method according).

now, if a I-Signalgroup is added which contains END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS it will follow the TRANSFORMER-REF to get the correct E2E-Profile and store this together with the data-ids into a dictionary which will be added to the Signalgroup itself.

for me thats the most simple way to implement this.

BUT: imho the fact that there are different kinds of SignalGroups available in the arxml should also be refelcted by canmatrix, so imho canmatrix should read the System-Signalgroup AS WELL as the I-Signalgroup and store both into the canmatrix object.