### PR TITLE
Kankan patch1

### DIFF
--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -78,6 +78,8 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--signals', help="Copy only given Signals (comma separated list) to target matrix just as 'free' signals without containing frame")
 @click.option('--merge', help="merge additional can databases.\nSyntax: --merge filename[:ecu=SOMEECU][:frame=FRAME1][:frame=FRAME2],filename2")
 @click.option('--ignorePduContainer/--no-ignorePduContainer', 'ignorePduContainer', default = False, help="Ignore any Frame with PDU container; if no export as multiplexed Frames\ndefault False")
+@click.option('--calcSignalMax/--no-calcSignalMax', 'calcSignalMax', default = False, help="Calculate Signals Maximum Physical Value; If maximum value is set to 0\ndefault False")
+@click.option('--recalcSignalMax/--no-recalcSignalMax', 'recalcSignalMax', default = False, help="Recalculate Signals Maximum Physical Value for the entire database\ndefault False")
 
 
 # arxml switches

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -30,7 +30,7 @@ from builtins import *
 import canmatrix
 import canmatrix.copy
 import canmatrix.formats
-import canmatrix.logd
+import canmatrix.log
 
 logger = logging.getLogger(__name__)
 sys.path.append('..')  # todo remove?

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -30,7 +30,7 @@ from builtins import *
 import canmatrix
 import canmatrix.copy
 import canmatrix.formats
-import canmatrix.log
+import canmatrix.logd
 
 logger = logging.getLogger(__name__)
 sys.path.append('..')  # todo remove?
@@ -250,6 +250,19 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
         if options.get('signalNameFromAttrib') is not None:
             for signal in [b for a in db for b in a.signals]:
                 signal.name = signal.attributes.get(options.get('signalNameFromAttrib'), signal.name)
+
+        # Max Signal Value Calculation , if max value is 0
+        if options.get('calcSignalMax') is not None and options['calcSignalMax']:
+            for signal in [b for a in db for b in a.signals]:
+                if float(signal.max) == 0.0 or signal.max is None:
+                    signal.calc_max_for_none = True
+                    signal.set_max(None)
+
+        # Max Signal Value Calculation
+        if options.get('recalcSignalMax') is not None and options['recalcSignalMax']:
+            for signal in [b for a in db for b in a.signals]:
+                signal.calc_max_for_none = True
+                signal.set_max(None)
 
         logger.info(name)
         logger.info("%d Frames found" % (db.frames.__len__()))


### PR DESCRIPTION
During dbc to dbc conversion using convert.py , I want to check the maximum value of the signals, if its zero or does not exist then calculate maximum value and update the dbc. At present current options of CAN convert do not allow that or may be I have missed to notice the option , so I have added two options 

- calcSignalMax  : Calculate Signals Maximum Physical Value; If maximum value is set to 0 in the current database being converted.
- recalcSignalMax :  Recalculate Signals Maximum Physical Value for the entire database being converted. This will rewrite any custom max values.