### PR TITLE
Kankan patch :: Custom Signal Attributes are removed 

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -1817,8 +1817,8 @@ class CanMatrix(object):
                 for signal in frame.signals:
                     if signal_define in signal.attributes:
                         break
-            else:
-                defines_to_delete.add(signal_define)
+                else:
+                    defines_to_delete.add(signal_define)
         for element in defines_to_delete:
             del self.signal_defines[element]
 

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -78,6 +78,8 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--signals', help="Copy only given Signals (comma separated list) to target matrix just as 'free' signals without containing frame")
 @click.option('--merge', help="merge additional can databases.\nSyntax: --merge filename[:ecu=SOMEECU][:frame=FRAME1][:frame=FRAME2],filename2")
 @click.option('--ignorePduContainer/--no-ignorePduContainer', 'ignorePduContainer', default = False, help="Ignore any Frame with PDU container; if no export as multiplexed Frames\ndefault False")
+@click.option('--calcSignalMax/--no-calcSignalMax', 'calcSignalMax', default = False, help="Calculate Signals Maximum Physical Value; If maximum value is set to 0\ndefault False")
+@click.option('--recalcSignalMax/--no-recalcSignalMax', 'recalcSignalMax', default = False, help="Recalculate Signals Maximum Physical Value for the entire database\ndefault False")
 
 
 # arxml switches

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -30,7 +30,7 @@ from builtins import *
 import canmatrix
 import canmatrix.copy
 import canmatrix.formats
-import canmatrix.logd
+import canmatrix.log
 
 logger = logging.getLogger(__name__)
 sys.path.append('..')  # todo remove?

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -30,7 +30,7 @@ from builtins import *
 import canmatrix
 import canmatrix.copy
 import canmatrix.formats
-import canmatrix.log
+import canmatrix.logd
 
 logger = logging.getLogger(__name__)
 sys.path.append('..')  # todo remove?
@@ -250,6 +250,19 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
         if options.get('signalNameFromAttrib') is not None:
             for signal in [b for a in db for b in a.signals]:
                 signal.name = signal.attributes.get(options.get('signalNameFromAttrib'), signal.name)
+
+        # Max Signal Value Calculation , if max value is 0
+        if options.get('calcSignalMax') is not None and options['calcSignalMax']:
+            for signal in [b for a in db for b in a.signals]:
+                if float(signal.max) == 0.0 or signal.max is None:
+                    signal.calc_max_for_none = True
+                    signal.set_max(None)
+
+        # Max Signal Value Calculation
+        if options.get('recalcSignalMax') is not None and options['recalcSignalMax']:
+            for signal in [b for a in db for b in a.signals]:
+                signal.calc_max_for_none = True
+                signal.set_max(None)
 
         logger.info(name)
         logger.info("%d Frames found" % (db.frames.__len__()))

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -254,7 +254,7 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
         # Max Signal Value Calculation , if max value is 0
         if options.get('calcSignalMax') is not None and options['calcSignalMax']:
             for signal in [b for a in db for b in a.signals]:
-                if float(signal.max) == 0.0 or signal.max is None:
+                if signal.max == 0 or signal.max is None:
                     signal.calc_max_for_none = True
                     signal.set_max(None)
 


### PR DESCRIPTION
Referring to **Issue#610**

when converting with --deleteObsoleteDefines switch,  custom attributes are removed in the output DBC though atleast one of the signal in the dbc has the custom attribute. We can test this by running 
`python3 ./convert.py  --deleteObsoleteDefines  ./InputDBC.dbc ./OutputDBC.dbc` from the examples folder.

Moving the else condition to refer to the signal iterator for loop solves this issue. Feel free to update if this is not the intended solution.