### PR TITLE
Update guess_value method in utils.py

### DIFF
--- a/src/canmatrix/utils.py
+++ b/src/canmatrix/utils.py
@@ -5,6 +5,7 @@ import csv
 import shlex
 import sys
 import typing
+from string import hexdigits
 from builtins import *
 
 if sys.version_info >= (3, 5):
@@ -90,6 +91,12 @@ def guess_value(text_value):  # type: (str) -> str
         return "0"
     elif text_value in ["true", "on"]:
         return "1"
+    elif text_value[:2] == "0b":
+        if text_value[2:].isdecimal():
+            return str(int(text_value[2:], 2))
+    elif text_value[:2] == "0x":
+        if all([f in hexdigits for f in text_value[2:]]):
+            return str(int(text_value[2:], 16))
     return text_value
 
 


### PR DESCRIPTION
add a conversion of 0b and 0x string values into int string representation in the guess_value method

initial motivation was to get valid input values for the decimal.Decimal() class
since it crashed in the arxml.py file line 1234:

1232            if initvalue is not None and initvalue.text is not None:
1233                initvalue.text = canmatrix.utils.guess_value(initvalue.text)
1234               new_signal.initial_value = float_factory(initvalue.text)

i discovered the "decode_number" function as well but was not sure if the intention of the "guess_value" was to return a string always. 