### PR TITLE
Adding Few Check functions 

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -1817,8 +1817,8 @@ class CanMatrix(object):
                 for signal in frame.signals:
                     if signal_define in signal.attributes:
                         break
-            else:
-                defines_to_delete.add(signal_define)
+                else:
+                    defines_to_delete.add(signal_define)
         for element in defines_to_delete:
             del self.signal_defines[element]
 

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -90,6 +90,7 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--checkFloatingSignals/--no-checkFloatingSignals', 'checkFloatingSignals', default = False, help="if checkFloatingSignals is set, then unassigned signals to a frame/message will be warned \tdefault: False")
 
 
+
 # arxml switches
 @click.option('--arxmlIgnoreClusterInfo/--no-arxmlIgnoreClusterInfo', 'arxmlIgnoreClusterInfo', default=False, help="Ignore any can cluster info from arxml; Import all frames in one matrix\ndefault False")
 @click.option('--arxmlExportVersion', 'arVersion',  default="3.2.3", help="Set output AUTOSAR version\ncurrently only 3.2.3 and 4.1.0 are supported\ndefault 3.2.3")
@@ -103,6 +104,9 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--dbcExportEncoding', 'dbcExportEncoding', default="iso-8859-1", help="Export charset of dbc (relevant for units), maybe utf-8\ndefault iso-8859-1")
 @click.option('--dbcExportCommentEncoding', 'dbcExportCommentEncoding', default="iso-8859-1", help="Export charset of comments in dbc\ndefault iso-8859-1")
 @click.option('--dbcUniqueSignalNames/--no-dbcUniqueSignalNames', 'dbcUniqueSignalNames', default=True, help="Check if signal names are unique per frame")
+@click.option('--convertToExtended/--no-convertToExtended', 'convertToExtended', default = False, help="if convertToExtended is set , then the canmatrix will convert the dbc to extended format \tdefault: False")
+@click.option('--convertToJ1939/--no-convertToJ1939', 'convertToJ1939', default = False, help="if convertToJ1939 is set , then the canmatrix will convert the dbc to J1939 format \tdefault: False")
+
 # dbf switches
 @click.option('--dbfImportEncoding', 'dbfImportEncoding', default="iso-8859-1", help="Import charset of dbf, maybe utf-8\ndefault iso-8859-1")
 @click.option('--dbfExportEncoding', 'dbfExportEncoding', default="iso-8859-1", help="Export charset of dbf, maybe utf-8\ndefault iso-8859-1")

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -78,6 +78,8 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--signals', help="Copy only given Signals (comma separated list) to target matrix just as 'free' signals without containing frame")
 @click.option('--merge', help="merge additional can databases.\nSyntax: --merge filename[:ecu=SOMEECU][:frame=FRAME1][:frame=FRAME2],filename2")
 @click.option('--ignorePduContainer/--no-ignorePduContainer', 'ignorePduContainer', default = False, help="Ignore any Frame with PDU container; if no export as multiplexed Frames\ndefault False")
+@click.option('--calcSignalMax/--no-calcSignalMax', 'calcSignalMax', default = False, help="Calculate Signals Maximum Physical Value; If maximum value is set to 0\ndefault False")
+@click.option('--recalcSignalMax/--no-recalcSignalMax', 'recalcSignalMax', default = False, help="Recalculate Signals Maximum Physical Value for the entire database\ndefault False")
 
 
 # arxml switches

--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -80,6 +80,14 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--ignorePduContainer/--no-ignorePduContainer', 'ignorePduContainer', default = False, help="Ignore any Frame with PDU container; if no export as multiplexed Frames\ndefault False")
 @click.option('--calcSignalMax/--no-calcSignalMax', 'calcSignalMax', default = False, help="Calculate Signals Maximum Physical Value; If maximum value is set to 0\ndefault False")
 @click.option('--recalcSignalMax/--no-recalcSignalMax', 'recalcSignalMax', default = False, help="Recalculate Signals Maximum Physical Value for the entire database\ndefault False")
+@click.option('--deleteFloatingSignals/--no-deleteFloatingSignals', 'deleteFloatingSignals', default = False, help="if deleteFloatingSignals is set , then unassigned signals to a frame/message will be deleted \tdefault: False")
+
+#Frame/Signal Check switches
+@click.option('--checkFloatingFrames/--no-checkFloatingFrames', 'checkFloatingFrames', default = False, help="if checkFloatingFrames is set, CAN message/frame without sender node will be warned .\tdefault: False")
+@click.option('--checkSignalRange/--no-checkSignalRange', 'checkSignalRange', default = False, help="if checkSignalRange is set, then signals consisting raw min/max value set to 0 will be warned. \tdefault: False ")
+@click.option('--checkSignalUnit/--no-checkSignalUnit', 'checkSignalUnit', default = False, help="if checkSignalUnit is set , then signals without units and value table will be warned. \tdefault: False")
+@click.option('--checkSignalReceiver/--no-checkSignalReceiver', 'checkSignalReceiver', default = False, help="if checkSignalReceiver is set, then signals without an assigned Receiver will be warned \tdefault: False")
+@click.option('--checkFloatingSignals/--no-checkFloatingSignals', 'checkFloatingSignals', default = False, help="if checkFloatingSignals is set, then unassigned signals to a frame/message will be warned \tdefault: False")
 
 
 # arxml switches

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -264,6 +264,49 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
                 signal.calc_max_for_none = True
                 signal.set_max(None)
 
+        # Delete Unassigned Signals to a Valid Frame/Message
+        if options.get('deleteFloatingSignals') is not None and options['deleteFloatingSignals']:
+            for frame in db.frames:
+                if frame.name == 'VECTOR__INDEPENDENT_SIG_MSG':
+                    for signal in frame:
+                        db.del_signal(signal)
+                        logger.info("Deleted %s",(frame.name+"::"+signal.name))
+                    db.del_frame(frame)
+
+        # Check & Warn for Receiver Node against signals
+        if options.get('checkSignalReceiver') is not None and options['checkSignalReceiver']:
+            for frame in db.frames:
+                for signal in frame:
+                    if len(signal.receivers) == 0:
+                        logger.warning("Please add Receiver for the signal %s ",(frame.name+"::"+signal.name))
+
+        # Check & Warn Unassigned Signals to a Valid Frame/Message
+        if options.get('checkFloatingSignals') is not None and options['checkFloatingSignals']:
+            for frame in db.frames:
+                if frame.name == 'VECTOR__INDEPENDENT_SIG_MSG':
+                    for signal in frame:
+                        logger.warning("Please map the signal %s to a valid frame or delete by deleteFloatingSignals", signal.name)
+
+        # Check & Warn for Frame/Messages without Transmitter Node
+        if options.get('checkFloatingFrames') is not None and options['checkFloatingFrames']:
+            for frame in db.frames:
+                if len(frame.transmitters) is 0:
+                    logger.warning("No Transmitter Node Found for Frame %s", frame.name)
+
+        # Check & Warn for Signals with Min/Max set to 0
+        if options.get('checkSignalRange') is not None and options['checkSignalRange']:
+            for frame in db.frames:
+                for signal in frame.signals:
+                    if (signal.phys2raw(signal.max) - signal.phys2raw(signal.min)) is 0:
+                        logger.warning("Invalid Min , Max value of %s", (frame.name+"::"+signal.name))
+
+        # Check for Signals without unit and Value table , the idea is to improve signal readability
+        if options.get('checkSignalUnit') is not None and options['checkSignalUnit']:
+            for frame in db.frames:
+                for signal in frame:
+                    if signal.unit is "" and len(signal.values) == 0:
+                        logger.warning("Please add value table for the signal %s or add appropriate Unit", (frame.name+"::"+signal.name))
+
         logger.info(name)
         logger.info("%d Frames found" % (db.frames.__len__()))
 

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -30,7 +30,7 @@ from builtins import *
 import canmatrix
 import canmatrix.copy
 import canmatrix.formats
-import canmatrix.logd
+import canmatrix.log
 
 logger = logging.getLogger(__name__)
 sys.path.append('..')  # todo remove?

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -307,6 +307,18 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
                     if signal.unit is "" and len(signal.values) == 0:
                         logger.warning("Please add value table for the signal %s or add appropriate Unit", (frame.name+"::"+signal.name))
 
+        # Convert dbc from J1939 to Extended format
+        if options.get('convertToExtended') is not None and options['convertToExtended']:
+            for frame in db.frames:
+                frame.is_j1939=False
+            db.add_attribute("ProtocolType","ExtendedCAN")
+
+        # Convert dbc from Extended to J1939 format
+        if options.get('convertToJ1939') is not None and options['convertToJ1939']:
+            for frame in db.frames:
+                frame.is_j1939=True
+            db.add_attribute("ProtocolType","J1939")
+
         logger.info(name)
         logger.info("%d Frames found" % (db.frames.__len__()))
 

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -30,7 +30,7 @@ from builtins import *
 import canmatrix
 import canmatrix.copy
 import canmatrix.formats
-import canmatrix.log
+import canmatrix.logd
 
 logger = logging.getLogger(__name__)
 sys.path.append('..')  # todo remove?
@@ -250,6 +250,19 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
         if options.get('signalNameFromAttrib') is not None:
             for signal in [b for a in db for b in a.signals]:
                 signal.name = signal.attributes.get(options.get('signalNameFromAttrib'), signal.name)
+
+        # Max Signal Value Calculation , if max value is 0
+        if options.get('calcSignalMax') is not None and options['calcSignalMax']:
+            for signal in [b for a in db for b in a.signals]:
+                if float(signal.max) == 0.0 or signal.max is None:
+                    signal.calc_max_for_none = True
+                    signal.set_max(None)
+
+        # Max Signal Value Calculation
+        if options.get('recalcSignalMax') is not None and options['recalcSignalMax']:
+            for signal in [b for a in db for b in a.signals]:
+                signal.calc_max_for_none = True
+                signal.set_max(None)
 
         logger.info(name)
         logger.info("%d Frames found" % (db.frames.__len__()))

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -254,7 +254,7 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
         # Max Signal Value Calculation , if max value is 0
         if options.get('calcSignalMax') is not None and options['calcSignalMax']:
             for signal in [b for a in db for b in a.signals]:
-                if float(signal.max) == 0.0 or signal.max is None:
+                if signal.max == 0 or signal.max is None:
                     signal.calc_max_for_none = True
                     signal.set_max(None)
 


### PR DESCRIPTION
Added below functions to the canconvert script , which we found useful in maintaining database.

1. **deleteFloatingSignals**  : Unassigned signals to a frame/message will be deleted.
2. **checkFloatingFrames** : CAN message/frame without sender node will be warned
3. **checkSignalRange** : Signals consisting raw min/max value set to 0 will be warned
4. **checkSignalUnit** : Signals without units and value table will be warned.
5. **checkSignalReceiver** : Signals without an assigned Receiver will be warned
6. **checkFloatingSignals** : Unassigned signals to a frame/message will be warned