### PR TITLE
add pdu_name to frame which represents the pdu-name of the pdu-frame-…

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -883,6 +883,7 @@ class Frame(object):
     pdus = attr.ib(factory=list)  # type: typing.MutableSequence[Pdu]
     header_id = attr.ib(default=None)  #type: int
     # header_id
+    pdu_name = attr.ib(default="")  # type: str
 
     @property
     def is_multiplexed(self):  # type: () -> bool

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1546,7 +1546,8 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
     if pdu is None:
         logger.error("pdu is None")
     else:
-        logger.debug("PDU: " + ea.get_element_name(pdu))
+        new_frame.pdu_name = ea.get_element_name(pdu)
+        logger.debug("PDU: " + new_frame.pdu_name)
 
     if new_frame.comment is None:
         new_frame.add_comment(ea.get_element_desc(pdu))


### PR DESCRIPTION
Until now the Name of the PDU which is mapped to the frame is not accesible via CanMatrix.
Now add a attribute 'pdu_name' to the Class Frame which represents the name of the PDU which is mapped to the Frame.

Hint:
In arxml it's possible that more than one PDU is mapped to a frame, but this is not supported at all in CanMatrix, so this pdu-name is also not a list.
This does NOT conflict with Container-PDU's (where the name is already available).