### PR TITLE
Fix JSON load when id is extended

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -744,7 +744,7 @@ class ArbitrationId(object):
     def from_compound_integer(cls, i):  # type: (typing.Any) -> ArbitrationId
         return cls(
             id=i & cls.extended_id_mask,
-            extended=(i & cls.compound_extended_mask) != 0,
+            extended=((i & cls.compound_extended_mask) | (i & cls.extended_id_mask) )!= 0,
         )
 
     @classmethod

--- a/src/canmatrix/convert.py
+++ b/src/canmatrix/convert.py
@@ -300,7 +300,7 @@ def convert(infile, out_file_name, **options):  # type: (str, str, **str) -> Non
         # Check & Warn for Frame/Messages without Transmitter Node
         if options.get('checkFloatingFrames') is not None and options['checkFloatingFrames']:
             for frame in db.frames:
-                if len(frame.transmitters) is 0:
+                if len(frame.transmitters) == 0:
                     logger.warning("No Transmitter Node Found for Frame %s", frame.name)
 
         # Check & Warn for Signals with Min/Max set to 0

--- a/src/canmatrix/formats/json.py
+++ b/src/canmatrix/formats/json.py
@@ -91,7 +91,7 @@ def dump(db, f, **options):
                     "is_float": signal.is_float,
                 })
             symbolic_frame = {"name": frame.name,
-                              "id": int(frame.arbitration_id.id),
+                              "id": int(frame.arbitration_id.to_compound_integer()),
                               "is_extended_frame": frame.arbitration_id.extended,
                               "is_fd": frame.is_fd,
                               "signals": symbolic_signals}
@@ -150,7 +150,7 @@ def dump(db, f, **options):
 
             export_dict['messages'].append(
                 {"name": frame.name,
-                 "id": int(frame.arbitration_id.id),
+                 "id": int(frame.arbitration_id.to_compound_integer()),
                  "is_extended_frame": frame.arbitration_id.extended,
                  "is_fd": frame.is_fd,
                  "signals": symbolic_signals,


### PR DESCRIPTION
Hi Eduard, thanks for your work on this project.

We were running into issues if we were to export to a JSON file and if any of the PGNs were extended ids, you could not load the exported JSON file in canmatrix. This fixed it for us.

Without this patch:

```
$ russ @ kalesmoothie in ~/work/can_j1939_pgns on  main ✖︎ [15:21:30]
↳ canconvert J1939.dbc /tmp/can.json   
ldf is not supported
xls is not supported
xlsx is not supported
INFO - convert - Importing J1939.dbc ... 
INFO - convert - done

INFO - convert - Exporting /tmp/can.json ... 
INFO - convert - 
INFO - convert - 546 Frames found
INFO - convert - done
```

```
$ russ @ kalesmoothie in ~/work/can_j1939_pgns on  main ✖︎ [15:21:35]
↳ canconvert /tmp/can.json /tmp/can.dbc
ldf is not supported
xls is not supported
xlsx is not supported
INFO - convert - Importing /tmp/can.json ... 
Traceback (most recent call last):
  File "/home/russ/.local/bin/canconvert", line 8, in <module>
    sys.exit(cli_convert())
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/cli/convert.py", line 153, in cli_convert
    canmatrix.convert.convert(infile, outfile, **options)
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/convert.py", line 68, in convert
    dbs = canmatrix.formats.loadp(infile, **options)
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/formats/__init__.py", line 71, in loadp
    return load(fileObject, import_type, key, **options)
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/formats/__init__.py", line 90, in load
    dbs[key] = module_instance.load(file_object, **options)  # type: ignore
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/formats/json.py", line 198, in load
    new_frame = canmatrix.Frame(frame["name"], arbitration_id=frame["id"], size=8)
  File "<attrs generated init canmatrix.canmatrix.Frame>", line 3, in __init__
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/canmatrix.py", line 73, in arbitration_id_converter
    return source if isinstance(source, ArbitrationId) else  ArbitrationId.from_compound_integer(source)
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/canmatrix.py", line 733, in from_compound_integer
    return cls(
  File "<attrs generated init canmatrix.canmatrix.ArbitrationId>", line 4, in __init__
  File "/home/russ/.local/lib/python3.10/site-packages/canmatrix/canmatrix.py", line 625, in __attrs_post_init__
    raise ArbitrationIdOutOfRange('ID out of range')
canmatrix.canmatrix.ArbitrationIdOutOfRange: ID out of range
```