### PR TITLE
Fix importlib.metadata issue on Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         "click",
         "enum34; python_version < '3.4'",
         "future",
+        "importlib-metadata; python_version < '3.8'",
         "six",
         "typing; python_version < '3.5'",
     ],

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -34,10 +34,10 @@ import itertools
 import logging
 import math
 import struct
+import sys
 import typing
 import warnings
 from builtins import *
-import importlib.metadata
 
 import attr
 from past.builtins import basestring
@@ -47,7 +47,12 @@ import canmatrix.copy
 import canmatrix.types
 import canmatrix.utils
 
-if importlib.metadata.version("attrs") < '17.4.0':
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
+if version("attrs") < '17.4.0':
     raise RuntimeError("need attrs >= 17.4.0")
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Commit 46d4de4 (#700) breaks compatibility with any Python version below 3.8. 

This fixes this issue by using `importlib-metadata` for those versions.