### PR TITLE
Filter out None results in selector

### DIFF
--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -298,7 +298,7 @@ class Earxml:
                                 filtered_results.append(tag)
                     result_list = filtered_results
 
-                result_list = list(set(result_list))
+                result_list = [result for result in set(result_list) if result is not None]
 
             last_found_token = found_token[1] + start_pos
             token = selector[start_pos + found_token[0]:start_pos + found_token[1]]

--- a/src/canmatrix/tests/ARXMLSecuredPDUTest.arxml
+++ b/src/canmatrix/tests/ARXMLSecuredPDUTest.arxml
@@ -7,7 +7,7 @@
         <CAN-CLUSTER>
           <SHORT-NAME>CAN</SHORT-NAME>
           <PHYSICAL-CHANNELS>
-            <PHYSICAL-CHANNEL>
+            <CAN-PHYSICAL-CHANNEL>
               <SHORT-NAME>CAN</SHORT-NAME>
               <FRAME-TRIGGERINGSS>
                 <CAN-FRAME-TRIGGERING>
@@ -62,7 +62,7 @@
                   <SIGNAL-REF DEST="I-SIGNAL">/ISignal/Signal</SIGNAL-REF>
                 </I-SIGNAL-TRIGGERING>
               </I-SIGNAL-TRIGGERINGS>
-            </PHYSICAL-CHANNEL>
+            </CAN-PHYSICAL-CHANNEL>
           </PHYSICAL-CHANNELS>
         </CAN-CLUSTER>
       </ELEMENTS>


### PR DESCRIPTION
This is trying to avoid exceptions like the following when the selector can't find matches. 

```
AttributeError: 'NoneType' object has no attribute 'sourceline'
```