### PR TITLE
Log unsupported formats as debug instead of warning

### DIFF
--- a/src/canmatrix/formats/__init__.py
+++ b/src/canmatrix/formats/__init__.py
@@ -25,7 +25,7 @@ for module in moduleList:
         importlib.import_module("canmatrix.formats." + module)
         loadedFormats.append(module)
     except ImportError:
-        logger.warning("%s is not supported", module)
+        logger.debug("%s is not supported", module)
 
 for loadedModule in loadedFormats:
     supportedFormats[loadedModule] = []


### PR DESCRIPTION
This commit spares the user from seeing **all** unsupported formats printed in the console when running canconvert or cancompare or just `import canmatrix` or using another package (like asammdf) which has a dependency on canmatrix. 

If a user tries to use a format that is not supported for them, an error will be logged saying that format is not supported, and that I think should be enough.