### PR TITLE
add a suffix containing file name in cluster name

### DIFF
--- a/src/canmatrix/formats/fibex.py
+++ b/src/canmatrix/formats/fibex.py
@@ -434,7 +434,9 @@ def dump(db, f, **options):
     clusters = create_sub_element_fx(elements, "CLUSTERS")
     cluster = lxml.etree.SubElement(clusters, ns_fx + "CLUSTER")
     cluster.set('ID', 'canCluster1')
-    create_short_name_desc(cluster, "clusterShort", "clusterDesc")
+    # add the file name as a suffix in the cluster name
+    cluster_name = f"cluster_{f.name.split('.')[0]}"
+    create_short_name_desc(cluster, cluster_name, "clusterDesc")
     create_sub_element_fx(cluster, "SPEED", "500")
     create_sub_element_fx(cluster, "IS-HIGH-LOW-BIT-ORDER", "true")
     create_sub_element_fx(cluster, "BIT-COUNTING-POLICY", "MONOTONE")


### PR DESCRIPTION
The main idea is to avoid having the same default name `clusterShort` for the clusters created when converting a dbc to a fibex file.