### PR TITLE
remove six usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ Environment :: Console
 License :: OSI Approved :: BSD License
 Topic :: Scientific/Engineering
 Programming Language :: Python
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
@@ -94,9 +93,7 @@ setup(
     install_requires = [
         "attrs>=19.2.0",
         "click",
-        "enum34; python_version < '3.4'",
         "importlib-metadata; python_version < '3.8'",
-        "six",
         "typing; python_version < '3.5'",
     ],
     extras_require = {

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -26,8 +26,6 @@
 
 # TODO: Definitions should be disassembled
 
-from __future__ import absolute_import, division, print_function
-
 import decimal
 import fnmatch
 import itertools
@@ -40,7 +38,7 @@ import warnings
 from builtins import *
 
 import attr
-from six.moves import zip_longest
+from itertools import zip_longest
 
 import canmatrix.copy
 import canmatrix.types


### PR DESCRIPTION
PR #744 broke Python 2.7 support. Can we go on and remove the remaining hybridation ?
(greetings)

https://github.com/ebroecker/canmatrix/pull/744/files

https://github.com/ebroecker/canmatrix/issues/742

