### PR TITLE
Use individual signal's "GenSigStartValue" as default value when merging dbc files

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -34,6 +34,7 @@ import math
 import struct
 import sys
 import typing
+from typing import Optional
 import warnings
 from builtins import *
 
@@ -467,7 +468,7 @@ class Signal(object):
         """
         if self.is_float:
             value = self.float_factory(value)
-                                                                                                            
+
         if decode_to_str:
             for value_key, value_string in self.values.items():
                 if value_key == value:
@@ -843,10 +844,10 @@ class Pdu(object):
         self.signals.append(signal)
         return self.signals[len(self.signals) - 1]
 
-    def add_signal_group(self, 
-                         Name: str, 
-                         Id: int, 
-                         signalNames: typing.Sequence[str], 
+    def add_signal_group(self,
+                         Name: str,
+                         Id: int,
+                         signalNames: typing.Sequence[str],
                          e2e_properties: Optional[AutosarE2EProperties] = None) -> None:
         """Add new SignalGroup to the Frame. Add given signals to the group.
 
@@ -920,7 +921,7 @@ class Frame(object):
     attributes = attr.ib(factory=dict)  # type: typing.MutableMapping[str, typing.Any]
     receivers = attr.ib(factory=list)  # type: typing.MutableSequence[str]
     signalGroups = attr.ib(factory=list)  # type: typing.MutableSequence[SignalGroup]
-    
+
     cycle_time = attr.ib(default=0)  # type: int
 
     is_j1939 = attr.ib(default=False)  # type: bool
@@ -932,7 +933,7 @@ class Frame(object):
 
     header_id = attr.ib(default=None)  # type: int
     endpoints = attr.ib(default=None)  # type: typing.MutableSequence[Endpoint]
-    
+
     secOC_properties = attr.ib(default=None)  # type:  Optional[AutosarSecOCProperties]
 
     @property
@@ -1059,9 +1060,9 @@ class Frame(object):
         return iter(self.signals)
 
     def add_signal_group(self,
-                         Name: str, 
-                         Id: int, 
-                         signalNames: typing.Sequence[str], 
+                         Name: str,
+                         Id: int,
+                         signalNames: typing.Sequence[str],
                          e2e_properties: Optional[AutosarE2EProperties] = None) -> None:
         """Add new SignalGroup to the Frame. Add given signals to the group.
 
@@ -1439,7 +1440,7 @@ class Frame(object):
 
         return unpacked
 
-    def unpack(self, data: bytes, 
+    def unpack(self, data: bytes,
                allow_truncated: bool = False,
                allow_exceeded: bool = False,
                ) -> typing.Mapping[str, DecodedSignal]:
@@ -1466,7 +1467,7 @@ class Frame(object):
             if allow_exceeded:
                 # trim the payload data to match the expected size
                 data = data[:self.size]
-            
+
             if len(data) != self.size:
                 # return None
                 raise DecodingFrameLength(
@@ -1614,7 +1615,7 @@ class Frame(object):
 
         else:
             return decoded
-    
+
     def _compress_little(self):
         for signal in self.signals:
             if not signal.is_little_endian:
@@ -1635,7 +1636,7 @@ class Frame(object):
                             gap_len += 1
                     else:
                         if gap_len is not None:
-                            signal = layout[bit_nr][0] 
+                            signal = layout[bit_nr][0]
                             signal.start_bit -= gap_len
                             gap_found = True
                             break
@@ -1657,7 +1658,7 @@ class Frame(object):
                         free_start = bit_nr
                 else:
                     if free_start is not None:
-                        signal = layout[bit_nr][0] 
+                        signal = layout[bit_nr][0]
                         signal.start_bit = free_start
                         gap_found = True
                         break
@@ -1970,7 +1971,7 @@ class CanMatrix(object):
                 # found ID while ignoring extended or standard
                 return test
         return None
-    
+
     def frame_by_header_id(self, header_id):  # type: (HeaderId) -> typing.Union[Frame, None]
         """Get Frame by its Header id.
 
@@ -2016,7 +2017,7 @@ class CanMatrix(object):
             if test.name == name:
                 return test
         return None
-    
+
     def get_frame_by_name(self, name):  # type: (str) -> typing.Union[Frame, None]
         """Get Frame by name.
 
@@ -2360,8 +2361,8 @@ class CanMatrix(object):
             if frame.size > 8:
                 frame.is_fd = True
 
-    def encode(self, 
-               frame_id: ArbitrationId, 
+    def encode(self,
+               frame_id: ArbitrationId,
                data: typing.Mapping[str, typing.Any]
                ) -> bytes:
         """Return a byte string containing the values from data packed

--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -238,12 +238,7 @@ def dump(in_db, f, **options):
             if signal.cycle_time != 0:
                 signal.add_attribute("GenSigCycleTime", signal.cycle_time)
             if "GenSigStartValue" in db.signal_defines:
-                if signal.phys2raw(None) != 0:
-                    if db.signal_defines["GenSigStartValue"].defaultValue is not None and \
-                            float(signal.initial_value) != float(db.signal_defines["GenSigStartValue"].defaultValue):
-                        signal.add_attribute("GenSigStartValue", signal.phys2raw(float(db.signal_defines["GenSigStartValue"].defaultValue)))
-                    elif db.signal_defines["GenSigStartValue"].defaultValue is None:
-                        signal.add_attribute("GenSigStartValue", signal.phys2raw(None))
+                signal.add_attribute("GenSigStartValue", signal.phys2raw(None))
 
             name = normalized_names[signal]
             if compatibility:
@@ -955,11 +950,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
         #     frame.extended = 1
 
         for signal in frame.signals:
-            if "GenSigStartValue" in db.signal_defines \
-                    and db.signal_defines["GenSigStartValue"].defaultValue is not None:
-                default_value = signal.phys2raw(float_factory(db.signal_defines["GenSigStartValue"].defaultValue))
-            else:
-                default_value = signal.phys2raw(None)
+            default_value = signal.phys2raw(None)
             gen_sig_start_value = float_factory(signal.attributes.get("GenSigStartValue", default_value))
             signal.initial_value = (gen_sig_start_value * signal.factor) + signal.offset
             signal.cycle_time = int(signal.attributes.get("GenSigCycleTime", 0))


### PR DESCRIPTION
The previous code used the db's GenSigStartValue as the default value for all signals.  That should only be used if an individual signal doesn't have a GenSigStartValue.  This fixes signal's losing their GenSigStartValue after a dbc merge.  Sometimes it would cause the GenSigStartValue to be outside of the min / max value.
Also specifically imported Optional so the code would run in Python 3.12.