### PR TITLE
fix can fd in fibex

### DIFF
--- a/src/canmatrix/formats/fibex.py
+++ b/src/canmatrix/formats/fibex.py
@@ -511,6 +511,9 @@ def dump(db, f, **options):
         create_sub_element_fx(identifier, "IDENTIFIER-VALUE", str(frame.arbitration_id.id))
         frame_ref = create_sub_element_fx(frame_triggering, "FRAME-REF")
         frame_ref.set("ID-REF", "FRAME_" + frame.name)
+        if (frame.is_fd):
+            create_sub_element_fx(frame_triggering, "CAN-FRAME-TX-BEHAVIOR","CAN-FD")
+            create_sub_element_fx(frame_triggering, "CAN-FRAME-RX-BEHAVIOR","CAN-FD")
 
     #
     # ECUS


### PR DESCRIPTION
@ebroecker , Regarding the CAN FD in DBC 
canmatrix does read this property from the DBC and populate the "is_fd" proeprty 
The code in canmatrix that writes back FIBEX, does not take it into consideration