### PR TITLE
Add support for IPv6 addresses in AUTOSAR endpoint parsing

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -36,6 +36,7 @@ import sys
 import typing
 import warnings
 from builtins import *
+from typing import Optional
 
 import attr
 from itertools import zip_longest
@@ -792,10 +793,14 @@ class Endpoint(object):
 
     AUTOSAR Ethernet Frames Endpoints
     """
-    server_ip = attr.ib(default="")  # type: str
+    server_ipv4 = attr.ib(default=None)  # type: Optional[str]
+    server_ipv6 = attr.ib(default=None)  # type: Optional[str]
     server_port = attr.ib(default=0)  # type: int
-    client_ip = attr.ib(default="")  # type: str
+
+    client_ipv4 = attr.ib(default=None)  # type: Optional[str]
+    client_ipv6 = attr.ib(default=None)  # type: Optional[str]
     client_port = attr.ib(default=0)  # type: int
+
     ttl = attr.ib(default=0)  # type: int
 
 

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1885,10 +1885,12 @@ def decode_ethernet_helper(ea, float_factory):
                 # Get Server Endpoint Info
                 server_port_ref = ea.follow_ref(socket_connection_bundle, "SERVER-PORT-REF")
                 server_port = ea.find("PORT-NUMBER", server_port_ref)
-                
+
                 server_app_endpoint = ea.get_child(server_port_ref, "APPLICATION-ENDPOINT")
                 server_endpoint_ref = ea.follow_ref(server_app_endpoint, "NETWORK-ENDPOINT-REF")
+
                 server_ipv4 = ea.find("IPV-4-ADDRESS", server_endpoint_ref)
+                server_ipv6 = ea.find("IPV-6-ADDRESS", server_endpoint_ref)
 
                 # Get Client Endpoint Info
                 socket_connections = ea.get_children(socket_connection_bundle, "SOCKET-CONNECTION")
@@ -1898,14 +1900,23 @@ def decode_ethernet_helper(ea, float_factory):
 
                     client_app_endpoint = ea.get_child(client_port_ref, "APPLICATION-ENDPOINT")
                     client_endpoint_ref = ea.follow_ref(client_app_endpoint, "NETWORK-ENDPOINT-REF")
+
                     client_ipv4 = ea.find("IPV-4-ADDRESS", client_endpoint_ref)
+                    client_ipv6 = ea.find("IPV-6-ADDRESS", client_endpoint_ref)
                     ttl = ea.find("TTL", client_endpoint_ref)
 
-                    endpoint = canmatrix.Endpoint(server_ipv4.text, 
-                                                  int(server_port.text, 0),
-                                                  client_ipv4.text, 
-                                                  int(client_port.text, 0),
-                                                  ttl)
+                    get_text = lambda el: el.text if el is not None else None
+                    get_int = lambda el: int(el.text, 0) if el is not None else 0
+
+                    endpoint = canmatrix.Endpoint(
+                        server_ipv4=get_text(server_ipv4),
+                        server_ipv6=get_text(server_ipv6),
+                        server_port=get_int(server_port),
+                        client_ipv4=get_text(client_ipv4),
+                        client_ipv6=get_text(client_ipv6),
+                        client_port=get_int(client_port),
+                        ttl=get_int(ttl)
+                    )
 
                     for scii in ea.findall("SOCKET-CONNECTION-IPDU-IDENTIFIER", socket_connection):
 


### PR DESCRIPTION
- Updated the Endpoint class to include IPv6 fields for both server and client.
- Modified ARXML parsing logic to extract and handle IPv6 addresses where available