### PR TITLE
Preferred languages

### DIFF
--- a/src/canmatrix/cli/convert.py
+++ b/src/canmatrix/cli/convert.py
@@ -95,6 +95,7 @@ Example --signalNameFromAttrib SysSignalName\nARXML known Attributes: SysSignalN
 @click.option('--arxmlExportVersion', 'arVersion',  default="4.1.0", help="Set output AUTOSAR version\ncurrently only 3.2.3 and 4.1.0 are supported\ndefault 4.1.0")
 @click.option('--arxmlFlexray/--no-arxmlFlexray', 'decode_flexray', default = False, help="EXPERIMENTAL: import basic flexray data from ARXML")
 @click.option('--arxmlEthernet/--no-arxmlEthernet', 'decode_ethernet', default = False, help="EXPERIMENTAL: import basic ethernet data from ARXML")
+@click.option('--preferred-languages', 'preferred_languages', default = "EN,DE", help="the preferred languages will be given priority when there are comments or descriptions available in multiple languages\ndefault EN,DE")
 
 
 # dbc switches

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -2172,7 +2172,7 @@ def load(file, **options):
     decode_ethernet = options.get("decode_ethernet", False)
     decode_flexray = options.get("decode_flexray", False)
 
-    preferred_languages = options.get("preferred_languages", ["EN", "DE"])
+    preferred_languages = options.get("preferred_languages", ["EN,DE"]).split(",")
 
     result = {}
     logger.debug("Read arxml ...")

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -230,8 +230,9 @@ class Earxml:
         txt = None
         for lang in self.preferred_languages:
             if txt is None:
-              txt = self.get_child(desc, f'L-2[@L="{lang}"]')
-              break
+                txt = self.get_child(desc, f'L-2[@L="{lang}"]')
+                if txt is None:
+                    break
         if txt is None:
             txt = self.get_child(desc, 'L-2')
         if txt is not None:
@@ -2173,6 +2174,8 @@ def load(file, **options):
     decode_flexray = options.get("decode_flexray", False)
 
     preferred_languages = options.get("preferred_languages", ["EN,DE"]).split(",")
+    preferred_languages.append("FOR-ALL")
+    logger.debug(f"preferred_languages: {preferred_languages}")
 
     result = {}
     logger.debug("Read arxml ...")

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -53,10 +53,11 @@ _FloatFactory = typing.Callable[[typing.Any], typing.Any]
 
 
 class Earxml:
-    def __init__(self):
+    def __init__(self, preferred_languages):
         self.xml_element_cache = dict()  # type: typing.Dict[str, _Element]
         self.path_cache = {}
         self.sn_cache = {}
+        self.preferred_languages = preferred_languages
 
     def fill_caches(self, start_element=None, ar_path=""):
         if start_element is None:
@@ -226,9 +227,11 @@ class Earxml:
         # type: (_Element, _DocRoot) -> str
         """Get element description from XML."""
         desc = self.get_child(element, "DESC")
-        txt = self.get_child(desc, 'L-2[@L="DE"]')
-        if txt is None:
-            txt = self.get_child(desc, 'L-2[@L="EN"]')
+        txt = None
+        for lang in self.preferred_languages:
+            if txt is None:
+              txt = self.get_child(desc, f'L-2[@L="{lang}"]')
+              break
         if txt is None:
             txt = self.get_child(desc, 'L-2')
         if txt is not None:
@@ -2169,10 +2172,12 @@ def load(file, **options):
     decode_ethernet = options.get("decode_ethernet", False)
     decode_flexray = options.get("decode_flexray", False)
 
+    preferred_languages = options.get("preferred_languages", ["EN", "DE"])
+
     result = {}
     logger.debug("Read arxml ...")
 
-    ea = Earxml()
+    ea = Earxml(preferred_languages = preferred_languages)
     ea.open(file)
 
     com_module = ea.get_short_name_path("/ActiveEcuC/Com")


### PR DESCRIPTION
I found it frustrating that the tool defaults to German comments without any ways to override.

This changes default to English, if available, otherwise German, FOR-ALL or anything at all.