### PR TITLE
Adds two new exceptions: DecodingContainerPdu and EncodingContainerPdu

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -69,8 +69,12 @@ class DecodingComplexMultiplexed(ExceptionTemplate): pass
 class DecodingFrameLength(ExceptionTemplate): pass
 class ArbitrationIdOutOfRange(ExceptionTemplate): pass
 class J1939NeedsExtendedIdentifier(ExceptionTemplate): pass
-class DecodingConatainerPdu(ExceptionTemplate): pass
-class EncodingConatainerPdu(ExceptionTemplate): pass
+class DecodingContainerPdu(ExceptionTemplate): pass
+class EncodingContainerPdu(ExceptionTemplate): pass
+class DecodingConatainerPdu(ExceptionTemplate):
+    warnings.warn("This exception is deprecated and should be removed. Consider using DecodingContainerPdu exception instead.")
+class EncodingConatainerPdu(ExceptionTemplate):
+    warnings.warn("This exception is deprecated and should be removed. Consider using DecodingContainerPdu exception instead.")
 
 
 def arbitration_id_converter(source):  # type: (typing.Union[int, ArbitrationId]) -> ArbitrationId

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -74,7 +74,7 @@ class EncodingContainerPdu(ExceptionTemplate): pass
 class DecodingConatainerPdu(ExceptionTemplate):
     warnings.warn("This exception is deprecated and should be removed. Consider using DecodingContainerPdu exception instead.")
 class EncodingConatainerPdu(ExceptionTemplate):
-    warnings.warn("This exception is deprecated and should be removed. Consider using DecodingContainerPdu exception instead.")
+    warnings.warn("This exception is deprecated and should be removed. Consider using EncodingContainerPdu exception instead.")
 
 
 def arbitration_id_converter(source):  # type: (typing.Union[int, ArbitrationId]) -> ArbitrationId


### PR DESCRIPTION
As per #861, typo has been fixed. To avoid breaking compatibility with 3rd party code using canmatrix, original exceptions with typo are left in, but a warning is added. This should also trigger a new point on the roadmap where a new version of canmatrix (i.e. v2.x) removes support for the deprecated entities altogether.