### PR TITLE
e2e add data_id_mode, prevent exception if PROFILE-NAME is not present

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -811,6 +811,7 @@ class Endpoint(object):
 @attr.s(eq=False)
 class AutosarE2EProperties(object):
     profile = attr.ib(default=None)  # type: str
+    data_id_mode = attr.ib(default=None)  # type: str
     data_ids = attr.ib(default=None) # type: List[int]
     data_length = attr.ib(default=None)  # type: int
 

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -998,19 +998,21 @@ def get_signalgrp_and_signals(sys_signal, sys_signal_array, frame, group_id, ea)
     transformer_ele = ea.follow_ref(sys_signal, "TRANSFORMER-REF")
     e2e_properties = None
     if transformer_ele is not None:
-        e2e_profile = ea.get_child(transformer_ele, "PROFILE-NAME").text
-       
+        _tmp_ele = ea.get_child(transformer_ele, "PROFILE-NAME")
+        e2e_profile = _tmp_ele.text if _tmp_ele is not None else None
+        _tmp_ele = ea.get_child(transformer_ele, "DATA-ID-MODE")
+        e2e_data_id_mode = _tmp_ele.text if _tmp_ele is not None else None
+
         trans_isignal_propss_elem = ea.get_child(sys_signal, "TRANSFORMATION-I-SIGNAL-PROPSS")
 
-        data_id_elems = ea.get_children(trans_isignal_propss_elem, "DATA-ID")
-        if data_id_elems is not None:
-            e2e_data_ids = [int(x.text, 0) for x in data_id_elems]
+        _tmp_ele = ea.get_children(trans_isignal_propss_elem, "DATA-ID")
+        if _tmp_ele is not None:
+            e2e_data_ids = [int(x.text, 0) for x in _tmp_ele]
 
-        data_len_elem = ea.get_child(trans_isignal_propss_elem, "DATA-LENGTH")
-        if data_len_elem is not None:
-            e2e_data_length = int(data_len_elem.text, 0)
+        _tmp_ele = ea.get_child(trans_isignal_propss_elem, "DATA-LENGTH")
+        e2e_data_length = int(_tmp_ele.text, 0) if _tmp_ele is not None else None
 
-        e2e_properties = canmatrix.AutosarE2EProperties(e2e_profile, e2e_data_ids, e2e_data_length)
+        e2e_properties = canmatrix.AutosarE2EProperties(e2e_profile, e2e_data_id_mode, e2e_data_ids, e2e_data_length)
 
     frame.add_signal_group(ea.get_element_name(sys_signal), group_id, members, e2e_properties)
 


### PR DESCRIPTION
!! DRAFT !!
this is part of an bigger change which i tried to split into several pull-requests.
But as the changes depends on each other the splited pull-requests will generate merge-conflicts.
So see this seperated pull-requests as some kind of documentation.
The "big" pull-request which contains everything in a single pull-request which do NOT generate merge-conflicts is: #873
---


just know the E2E-Profile is not precise enough for some E2E-Profiles (e.g. Profile-1).

Changes:
- add the DATA-ID-MODE to the AutosarE2EProperties and fill it.
- prevent exceptions if the PROFILE-NAME is not given.
- uniform checks