### PR TITLE
fix: do not generate invalid initial_values for Signals

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -455,8 +455,8 @@ class Signal(object):
         # if not (0 <= value <= 10):
         if not (self.min <= value <= self.max):
             logger.warning(
-                "Value {} is not valid for {}. Min={} and Max={}".format(
-                    value, self, self.min, self.max)
+                "Signal {}: Value {} is not valid for {}. Min={} and Max={}".format(
+                    self.name, value, self, self.min, self.max)
                 )
         raw_value = (self.float_factory(value) - self.float_factory(self.offset)) / self.float_factory(self.factor)
 

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1373,6 +1373,11 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
                     new_signal.initial_value = (float_factory(initvalue.text) * factor) + offset
                 except decimal.InvalidOperation:
                     logger.error("could not decode value {}".format(initvalue.text))
+            else:
+                # no init-value found, check if existing initialized initial_value of Signal-object is between min/max,
+                # if not => INVALID! => set it to min to at least not generate an invalid Signal
+                if new_signal.min > new_signal.initial_value or new_signal.max < new_signal.initial_value:
+                    new_signal.initial_value = new_signal.min
 
             for key, value in list(values.items()):
                 new_signal.add_values(canmatrix.utils.decode_number(key, float_factory), value)
@@ -1478,6 +1483,19 @@ def get_frame_from_container_ipdu(pdu, target_frame, ea, float_factory, headers_
         ipdu = ea.follow_ref(cpdu, "I-PDU-REF")
         if ipdu in ipdus_refs:
             continue
+        try:
+            if header_type == "SHORT-HEADER":
+                header_id = ea.get_child(ipdu, "HEADER-ID-SHORT-HEADER").text
+            elif header_type == "LONG-HEADER":
+                header_id = ea.get_child(ipdu, "HEADER-ID-LONG-HEADER").text
+            else:
+                # none type
+                header_id = None
+        except AttributeError:
+            header_id = None
+        if header_id is not None:
+            header_id = int(header_id, 0)
+
         ipdus_refs.append(ipdu)
         timing_spec = ea.get_child(ipdu, "I-PDU-TIMING-SPECIFICATION")
         if timing_spec is None:


### PR DESCRIPTION
!! DRAFT !!
this is part of an bigger change which i tried to split into several pull-requests.
But as the changes depends on each other the splited pull-requests will generate merge-conflicts.
So see this seperated pull-requests as some kind of documentation.
The "big" pull-request which contains everything in a single pull-request which do NOT generate merge-conflicts is: #873
---

it is possible that an arxml-file does NOT contain an initial_value for an signal.

but the class Signal need an initial_value (which make sense, because some initial-value is needed logically).

The current implementation sets the initial_value to 0 if the INITIAL_VALUE is missing in the arxml-file.
BUT if 0 is not allowed because of min/max value an inconsistent/invalid Signal is generated.

Solution: check if initial_value is between min/max. if not, set it to min.

(more or less it does not matter which value, each value between min/max is just a guess, but the current impementation make the fixed guess '0' without checking if that guess is valid)