### PR TITLE
Reverts frame_by_id behaviour

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -1989,7 +1989,7 @@ class CanMatrix(object):
         for element in defines_to_delete:
             del self.signal_defines[element]
 
-    def frame_by_id(self, arbitration_id):  # type: (ArbitrationId) -> typing.Union[Frame, None]
+    def get_frame_by_id(self, arbitration_id):  # type: (ArbitrationId) -> typing.Union[Frame, None]
         """Get Frame by its arbitration id.
 
         :param ArbitrationId arbitration_id: Frame id as canmatrix.ArbitrationId
@@ -2005,6 +2005,18 @@ class CanMatrix(object):
                 # found ID while ignoring extended or standard
                 self._frames_dict_id_extend[hash_name] = frame
                 return frame
+        return None
+    
+    def frame_by_id(self, arbitration_id):  # type: (ArbitrationId) -> typing.Union[Frame, None]
+        """Get Frame by its arbitration id.
+
+        :param ArbitrationId arbitration_id: Frame id as canmatrix.ArbitrationId
+        :rtype: Frame or None
+        """
+        for test in self.frames:
+            if test.arbitration_id == arbitration_id:
+                # found ID while ignoring extended or standard
+                return test
         return None
 
     def frame_by_header_id(self, header_id):  # type: (HeaderId) -> typing.Union[Frame, None]


### PR DESCRIPTION
This relates to [https://github.com/ebroecker/canmatrix/pull/825](https://github.com/ebroecker/canmatrix/pull/825?utm_source=chatgpt.com).

While speeding up `frame_by_id` is useful, it changes the original behavior: Our environment expects a fresh, up-to-date frame each call, whereas the cache may return outdated data (e.g. after renaming a frame).

To stay consistent with other APIs, I’d suggest keeping two variants:
- `get_frame_by_attribute`: cache-based
- `frame_by_attribute`: always searches

Alternatively, the cache could be reset whenever a frame attribute changes, but that would require much more intrusive changes. I’d prefer keeping the PR as minimally invasive as possible.