### PR TITLE
remove deprecated exceptions to avoid user-warnings

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -71,10 +71,6 @@ class ArbitrationIdOutOfRange(ExceptionTemplate): pass
 class J1939NeedsExtendedIdentifier(ExceptionTemplate): pass
 class DecodingContainerPdu(ExceptionTemplate): pass
 class EncodingContainerPdu(ExceptionTemplate): pass
-class DecodingConatainerPdu(ExceptionTemplate):
-    warnings.warn("This exception is deprecated and should be removed. Consider using DecodingContainerPdu exception instead.")
-class EncodingConatainerPdu(ExceptionTemplate):
-    warnings.warn("This exception is deprecated and should be removed. Consider using EncodingContainerPdu exception instead.")
 
 
 def arbitration_id_converter(source):  # type: (typing.Union[int, ArbitrationId]) -> ArbitrationId
@@ -1391,7 +1387,7 @@ class Frame(object):
         if self.is_complex_multiplexed:
             raise EncodingComplexMultiplexed
         elif self.is_pdu_container:
-            raise EncodingConatainerPdu  # TODO add encoding
+            raise EncodingContainerPdu  # TODO add encoding
         elif self.is_multiplexed:
             # search for mulitplexer-signal
             for signal in self.signals:

--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -1490,7 +1490,7 @@ class Frame(object):
             header_id_signal = self.signal_by_name("Header_ID")
             header_dlc_signal = self.signal_by_name("Header_DLC")
             if header_id_signal is None or header_dlc_signal is None:
-                raise DecodingConatainerPdu(
+                raise DecodingContainerPdu(
                     'Received message 0x{:08X} without Header_ID or '
                     'Header_DLC signal'.format(self.arbitration_id.id)
                 )

--- a/tests/test_frame_decoding.py
+++ b/tests/test_frame_decoding.py
@@ -211,7 +211,7 @@ def test_pdu_container_decoding_without_header():
     )
     frame.add_pdu(pdu)
     data = bytearray([0] * frame.size)
-    with pytest.raises(canmatrix.DecodingConatainerPdu):
+    with pytest.raises(canmatrix.DecodingContainerPdu):
         frame.decode(data)
 
 


### PR DESCRIPTION
recently two exceptions are declared as 'deprecated' which now cause user-warnings each time when the module is loaded, even if the exceptions are not used at all.

removed the deprecated exceptions (and use the mentioned ones where the deprecated ones are still used).