### PR TITLE
fix option "float_factory"

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -54,7 +54,6 @@ if version("attrs") < '17.4.0':
     raise RuntimeError("need attrs >= 17.4.0")
 
 logger = logging.getLogger(__name__)
-defaultFloatFactory = decimal.Decimal  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
 
 
 class ExceptionTemplate(Exception):
@@ -159,20 +158,19 @@ class Signal(object):
 
     name = attr.ib(default="")  # type: str
     # float_factory = attr.ib(default=defaultFloatFactory)
-    float_factory = defaultFloatFactory  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
+    float_factory = canmatrix.utils.FloatFactory.get_float  # type: typing.Callable[[typing.Any], canmatrix.types.PhysicalValue]
     start_bit = attr.ib(default=0)  # type: int
     size = attr.ib(default=0)  # type: int
     is_little_endian = attr.ib(default=True)  # type: bool
     is_signed = attr.ib(default=True)  # type: bool
-    offset = attr.ib(converter=float_factory, default=float_factory(0.0))  # type: canmatrix.types.PhysicalValue
+    offset = attr.ib(converter=float_factory)  # type: canmatrix.types.PhysicalValue
     factor = attr.ib(
         converter=lambda value, float_factory=float_factory: (
             float_factory(value)
-            if float(value) != 0
+            if float_factory(value) != 0
             else float_factory(1.0)
-        ),
-        default=float_factory(1.0)
-    )  # type: canmatrix.types.PhysicalValue
+        )
+    )  # type: # type: canmatrix.types.PhysicalValue
 
     unit = attr.ib(default="")  # type: str
     receivers = attr.ib(factory=list)  # type: typing.MutableSequence[str]
@@ -195,7 +193,7 @@ class Signal(object):
     calc_max_for_none = attr.ib(default=True)  # type: bool
 
     cycle_time = attr.ib(default=0)  # type: int
-    initial_value = attr.ib(converter=float_factory, default=float_factory(0.0))  # type: canmatrix.types.PhysicalValue
+    initial_value = attr.ib(converter=float_factory)  # type: canmatrix.types.PhysicalValue
     scale_ranges = attr.ib(factory=list)
     min = attr.ib(
         converter=lambda value, float_factory=float_factory: (
@@ -204,6 +202,25 @@ class Signal(object):
             else value
         )
     )  # type: typing.Union[int, decimal.Decimal, None]
+
+    @offset.default
+    def set_default_offset(self):
+        # default-factory can be changed by option, so we need to initialize it during object-creation
+        # to use the correct float-factory itstead of class-initialisation above
+        return canmatrix.utils.FloatFactory.get_float(0.0)
+
+    @factor.default
+    def set_default_factor(self):
+        # default-factory can be changed by option, so we need to initialize it during object-creation
+        # to use the correct float-factory itstead of class-initialisation above
+        return canmatrix.utils.FloatFactory.get_float(1.0)
+
+    @initial_value.default
+    def set_default_initial_value(self):
+        # default-factory can be changed by option, so we need to initialize it during object-creation
+        # to use the correct float-factory itstead of class-initialisation above
+        return canmatrix.utils.FloatFactory.get_float(0.0)
+
     @min.default
     def set_default_min(self):  # type: () -> canmatrix.types.OptionalPhysicalValue
         return self.set_min()
@@ -327,7 +344,7 @@ class Signal(object):
         :param int or str value: signal value (0xFF)
         :param str valueName: Human readable value description ("Init")
         """
-        if isinstance(value, defaultFloatFactory):
+        if isinstance(value, canmatrix.utils.FloatFactory.get_float_factory()):
             self.values[value.to_integral()] = valueName
         else:
             self.values[int(str(value), 0)] = valueName
@@ -1719,8 +1736,8 @@ class Define(object):
             :param str inStr: integer represented as string.
             :rtype: int
             """
-            out = int(defaultFloatFactory(inStr))
-            if out != defaultFloatFactory(inStr):
+            out = int(canmatrix.utils.FloatFactory.get_float(inStr))
+            if out != canmatrix.utils.FloatFactory.get_float(inStr):
                 logger.warning("Warning, integer was expected but got float: got: {0} using {1}\n".format(inStr, str(out)))
             return out
 
@@ -1753,8 +1770,8 @@ class Define(object):
         elif definition[0:5] == 'FLOAT':
             self.type = 'FLOAT'
             min, max = definition[6:].split(' ', 2)
-            self.min = defaultFloatFactory(min)
-            self.max = defaultFloatFactory(max)
+            self.min = canmatrix.utils.FloatFactory.get_float(min)
+            self.max = canmatrix.utils.FloatFactory.get_float(max)
 
     def set_default(self, default):  # type: (typing.Any) -> None
         """Set Definition default value.

--- a/src/canmatrix/formats/__init__.py
+++ b/src/canmatrix/formats/__init__.py
@@ -83,6 +83,10 @@ def load(file_object, import_type, key="", **options):
     # type: (typing.BinaryIO, str, str, **str) -> typing.Union[typing.Dict[str, canmatrix.CanMatrix], None]
     dbs = {}  # type: typing.Dict[str, canmatrix.CanMatrix]
     module_instance = sys.modules["canmatrix.formats." + import_type]
+    _float_factory = options.get('float_factory', None)
+    if _float_factory is not None:
+        # if we got a float-factory: set it here to the FloatFactory-helper
+        canmatrix.utils.FloatFactory.set_float_factory(_float_factory)
     if "clusterImporter" in supportedFormats[import_type]:
         dbs = module_instance.load(file_object, **options)  # type: ignore
     else:

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -40,7 +40,6 @@ import canmatrix.types
 import canmatrix.utils
 
 logger = logging.getLogger(__name__)
-default_float_factory = decimal.Decimal
 
 clusterExporter = 1
 clusterImporter = 1
@@ -999,7 +998,7 @@ def get_signalgrp_and_signals(sys_signal, sys_signal_array, frame, group_id, ea)
     e2e_properties = None
     if transformer_ele is not None:
         e2e_profile = ea.get_child(transformer_ele, "PROFILE-NAME").text
-       
+
         trans_isignal_propss_elem = ea.get_child(sys_signal, "TRANSFORMATION-I-SIGNAL-PROPSS")
 
         data_id_elems = ea.get_children(trans_isignal_propss_elem, "DATA-ID")
@@ -1134,12 +1133,12 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
                 isignal_array = ea.follow_all_ref(isignal, "I-SIGNAL-REF")
                 get_signalgrp_and_signals(isignal, isignal_array, frame, group_id, ea)
                 if ub_start_bit is not None:
-                    ub_name = ea.get_element_name(isignal) + "_UB"   
+                    ub_name = ea.get_element_name(isignal) + "_UB"
                     isignal_ub = canmatrix.Signal(ub_name,
                                                   start_bit=int(ub_start_bit.text, 0),
                                                   size = 1,
                                                   is_signed = False,
-                                                  unit = "Unitless") 
+                                                  unit = "Unitless")
                     frame.add_signal(isignal_ub)
 
                 group_id = group_id + 1
@@ -1610,8 +1609,8 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
                 data_id = ea.get_child(secured_ipdu_SecoC, "DATA-ID").text
                 freshness_bit_length = ea.get_child(secured_ipdu_SecoC, "FRESHNESS-VALUE-LENGTH").text
                 freshness_tx_length = ea.get_child(secured_ipdu_SecoC, "FRESHNESS-VALUE-TX-LENGTH").text
-                
-                secOC_properties = canmatrix.AutosarSecOCProperties(auth_algorithm, 
+
+                secOC_properties = canmatrix.AutosarSecOCProperties(auth_algorithm,
                                                                    int(payload_length, 0),
                                                                    int(auth_tx_length, 0),
                                                                    int(data_id, 0),
@@ -1641,7 +1640,7 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
                                                     size = int(freshness_tx_length, 0),
                                                     is_signed = False,
                                                     is_little_endian = False,
-                                                    unit = "Unitless") 
+                                                    unit = "Unitless")
                 new_frame.add_signal(signal_freshness)
 
             if auth_tx_length is not None and int(auth_tx_length, 0) > 0:
@@ -1653,7 +1652,7 @@ def get_frame(frame_triggering, ea, multiplex_translation, float_factory, header
                                                 is_little_endian = False,
                                                 unit = "Unitless")
                 new_frame.add_signal(signal_authinfo)
-        
+
         comment = ea.get_element_desc(frame_elem)
         if pdu is not None:
             new_frame.add_attribute("PduName", ea.get_short_name(pdu))
@@ -2178,7 +2177,7 @@ def load(file, **options):
     global frames_cache
     frames_cache = {}
 
-    float_factory = options.get("float_factory", default_float_factory)  # type: typing.Callable
+    float_factory = canmatrix.utils.FloatFactory.get_float_factory()  # type: typing.Callable
     ignore_cluster_info = options.get("arxmlIgnoreClusterInfo", False)
 
     decode_ethernet = options.get("decode_ethernet", False)

--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -37,10 +37,6 @@ import canmatrix.utils
 logger = logging.getLogger(__name__)
 
 
-def default_float_factory(value):  # type: (typing.Any) -> decimal.Decimal
-    return decimal.Decimal(value)
-
-
 def normalize_name(name, whitespace_replacement):  # type: (str, str) -> str
     name = re.sub(r'\s+', whitespace_replacement, name)
 
@@ -482,7 +478,7 @@ class _FollowUps(object):
 def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatrix
     dbc_import_encoding = options.get("dbcImportEncoding", 'iso-8859-1')
     dbc_comment_encoding = options.get("dbcImportCommentEncoding", dbc_import_encoding)
-    float_factory = options.get('float_factory', default_float_factory)
+    float_factory = canmatrix.utils.FloatFactory.get_float_factory()
 
     i = 0
 

--- a/src/canmatrix/formats/dbf.py
+++ b/src/canmatrix/formats/dbf.py
@@ -37,10 +37,6 @@ import canmatrix
 logger = logging.getLogger(__name__)
 
 
-def default_float_factory(value):  # type: (typing.Any) -> decimal.Decimal
-    return decimal.Decimal(value)
-
-
 # TODO support for [START_PARAM_NODE_RX_SIG]
 # TODO support for [START_PARAM_NODE_TX_MSG]
 
@@ -66,7 +62,7 @@ def decode_define(line):  # type: (str) -> typing.Tuple[str, str, str]
 
 def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatrix
     dbf_import_encoding = options.get("dbfImportEncoding", 'iso-8859-1')
-    float_factory = options.get('float_factory', default_float_factory)
+    float_factory = canmatrix.utils.FloatFactory.get_float_factory()
     is_j1939 = False
     db = canmatrix.CanMatrix()
 

--- a/src/canmatrix/formats/kcd.py
+++ b/src/canmatrix/formats/kcd.py
@@ -41,10 +41,6 @@ clusterImporter = 1
 _Element = lxml.etree._Element
 
 
-def default_float_factory(value):  # type: (typing.Any) -> decimal.Decimal
-    return decimal.Decimal(value)
-
-
 def create_signal(signal, node_list, type_enums):
     # type: (canmatrix.Signal, typing.Mapping[str, int], typing.Mapping[str, typing.Sequence[str]]) -> _Element
     xml_signal = lxml.etree.Element(
@@ -340,7 +336,7 @@ def parse_signal(signal, mux, namespace, nodelist, float_factory):
 
 def load(f, **options):
     # type: (typing.IO, **typing.Any) -> typing.Dict[str, canmatrix.CanMatrix]
-    float_factory = options.get("float_factory", default_float_factory)  # type: typing.Callable
+    float_factory = canmatrix.utils.FloatFactory.get_float_factory()  # type: typing.Callable
     dbs = {}  # type: typing.Dict[str, canmatrix.CanMatrix]
     tree = lxml.etree.parse(f)
     root = tree.getroot()

--- a/src/canmatrix/formats/sym.py
+++ b/src/canmatrix/formats/sym.py
@@ -38,10 +38,6 @@ import canmatrix.utils
 logger = logging.getLogger(__name__)
 
 
-def default_float_factory(value):  # type: (typing.Any) -> decimal.Decimal
-    return decimal.Decimal(value)
-
-
 @attr.s
 class ParsingError(Exception):
     line_number = attr.ib()  # type: int
@@ -328,7 +324,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
 
     calc_min_for_none = options.get('calc_min_for_none')
     calc_max_for_none = options.get('calc_max_for_none')
-    float_factory = options.get('float_factory', default_float_factory)
+    float_factory = canmatrix.utils.FloatFactory.get_float_factory()
 
     class Mode(object):
         glob, enums, send, sendReceive, receive = list(range(5))

--- a/src/canmatrix/formats/xls.py
+++ b/src/canmatrix/formats/xls.py
@@ -35,7 +35,6 @@ import canmatrix
 import canmatrix.formats.xls_common
 
 logger = logging.getLogger(__name__)
-default_float_factory = decimal.Decimal
 
 # Font Size : 8pt * 20 = 160
 # font = 'font: name Arial Narrow, height 160'
@@ -339,7 +338,7 @@ def read_additional_signal_attributes(signal, attribute_name, attribute_value):
 def load(file, **options):
     # type: (typing.IO, **typing.Any) -> canmatrix.CanMatrix
     motorola_bit_format = options.get("xlsMotorolaBitFormat", "msbreverse")
-    float_factory = options.get("float_factory", default_float_factory)
+    float_factory = canmatrix.utils.FloatFactory.get_float_factory()
 
     additional_inputs = dict()
     wb = xlrd.open_workbook(file_contents=file.read())

--- a/src/canmatrix/utils.py
+++ b/src/canmatrix/utils.py
@@ -6,6 +6,8 @@ import sys
 import typing
 from string import hexdigits
 from builtins import *
+from decimal import Decimal
+from typing import Any
 
 if sys.version_info >= (3, 5):
     import math
@@ -134,3 +136,30 @@ def decode_number(value, float_factory):  # type(string) -> (int)
         value = value[2:]
 
     return int(value, base)
+
+
+class FloatFactory:
+    """helper-class to get the float-factory
+    default: decimal.Decimal
+    use set_float_factory() to set an alternative float-factory (e.g. 'float')
+
+    usage-examples:
+      - get a value using the float-factory: FloatFactory.get_float(7)
+      - get the float-factory itself:        FloatFactory.get_float_factory()
+      - set a new float-factory:             FloatFactory.set_float_factory(float)
+      """
+
+    _default_float_factory = Decimal
+    _float_factory = None
+
+    @classmethod
+    def set_float_factory(cls, float_factory: callable):
+        cls._float_factory = float_factory
+
+    @classmethod
+    def get_float_factory(cls):
+        return cls._float_factory if cls._float_factory else cls._default_float_factory
+
+    @classmethod
+    def get_float(cls, value: Any):
+        return cls.get_float_factory()(value)


### PR DESCRIPTION
there was/is a feature in canmatrix that you can handover/change the float_factory.
by default decimal.Decimal is used.

since long time (also in canmatrix < 1.0) that feature is not working anymore (at least for me), but as in my setup decimal.Decimal is not working for me (cause followup-troubles) until now i used a local modified version where i changed 'decimal.Decimal' to 'float' because using the option 'float_factory' as option during the call of load() was not working.

Main reason was the initialisation of some members of the class Signal.

This PR now address this issue and now the caller of load() can handover float_factory=float (as example) and this is used without any errors (tested loading arxml and dbc files, also using the encoding and decoding feature of canmatrix).

overview of the changes:
- new class "FloatFactory" in utils.py
  there is the default-float-factory defined as decimal.Decimal
  there are methods to set/get the float_factory and also a get_float() to directly us it
- central evaluation of the "float_factory" option in formats/__init__.py in the load() method which set the requested float_factory in the FloatFactory Class
- get the float_factory from the FloatFactory Class where needed
- changed the initialisation of the Signal Class in canmatrix.py because until now a few members where initialized during class-creation, but the user may change the float_factory afterwards.

