### PR TITLE
changes to make it possible to use Cython for improved performance

### DIFF
--- a/src/canmatrix/canmatrix.py
+++ b/src/canmatrix/canmatrix.py
@@ -476,7 +476,6 @@ class Signal(object):
             for value_key, value_string in self.values.items():
                 if value_key == value:
                     return value_string
-                    break
 
         result = value * self.factor + self.offset  # type: typing.Union[canmatrix.types.PhysicalValue, str]
 
@@ -603,13 +602,13 @@ def unpack_bitstring(length, is_float, is_signed, bits):
     return value
 
 
-def pack_bitstring(length, is_float, value, signed):
+def pack_bitstring(length, is_float, value, is_signed):
     """
     returns a value in bits
     :param length: length of signal in bits
     :param is_float: value is float
     :param value: value to encode
-    :param signed: value is signed
+    :param is_signed: value is is_signed
     :return:
     """
     if is_float:


### PR DESCRIPTION
when someone (like me *g*) is using Cython for performance reasons it is not possible because the argument-name 'signed' is a reserved keyword in C.  

renamed (the unused) argument "signed" to "is_signed" (this name is already used inside canmatrix on all compareable locations).

also remove un-reachable "break" after "return" to avoid compiler-warnings.