### PR TITLE
Fix/arxml null safety

### DIFF
--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -1219,6 +1219,7 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
                 pass
 
         base_type_name = None
+        type_encoding = None
         base_type = ea.follow_ref(isignal, "BASE-TYPE-REF")  # AR4
         if base_type is None:
             a = ea.selector(isignal, ">SYSTEM-SIGNAL-REF>DATA-TYPE-REF>BASE-TYPE-REF")
@@ -1242,6 +1243,9 @@ def get_signals(signal_array, frame, ea, multiplex_id, float_factory, bit_offset
                     base_type_name = AutosarBasePlatformTypes.datatype_by_ref(_ele)
                     if type_encoding is not None:
                         break
+                # If type_encoding still None after loop, set default
+                if type_encoding is None:
+                    type_encoding = "NONE"
             else:
                 type_encoding = ea.get_child(base_type, "BASE-TYPE-ENCODING").text
                 base_type_name = ea.get_element_name(base_type)

--- a/src/canmatrix/formats/arxml.py
+++ b/src/canmatrix/formats/arxml.py
@@ -2212,7 +2212,7 @@ def decode_ethernet_helper(ea, float_factory, generated_update_bits_init_to_1: b
 
             vlan = ea.get_child(pc, "VLAN")
             vlan_tag = ea.get_child(vlan, "VLAN-IDENTIFIER")
-            db.vlan = int(vlan_tag.text, 0)
+            db.vlan = int(vlan_tag.text, 0) if vlan_tag is not None and vlan_tag.text else None
 
             found_matrixes[channel_name] = db
 
@@ -2253,7 +2253,8 @@ def decode_ethernet_helper(ea, float_factory, generated_update_bits_init_to_1: b
                         ttl=get_int(ttl)
                     )
 
-                    for scii in ea.findall("SOCKET-CONNECTION-IPDU-IDENTIFIER", socket_connection):
+                    pdus = ea.get_child(socket_connection, "PDUS")
+                    for scii in ea.findall("SOCKET-CONNECTION-IPDU-IDENTIFIER", pdus):
 
                         header_id = ea.get_child(scii, "HEADER-ID")
                         ipdu_triggering = ea.follow_ref(scii, "PDU-TRIGGERING-REF")


### PR DESCRIPTION
- Add null check for VLAN tag before parsing to prevent AttributeError
- Get PDUS child element before searching for SOCKET-CONNECTION-IPDU-IDENTIFIER
  to ensure proper XML hierarchy traversal
  ARXML Structure

```
    SOCKET-CONNECTION-BUNDLE
        └─ SOCKET-CONNECTION (multiple)
         └─ PDUS
            └─ SOCKET-CONNECTION-IPDU-IDENTIFIER
                ├─ HEADER-ID
                └─ PDU-TRIGGERING-REF
```