### PR TITLE
Preserve short signal names on alternate attribute

### DIFF
--- a/src/canmatrix/Signal.py
+++ b/src/canmatrix/Signal.py
@@ -54,6 +54,7 @@ class Signal(object):
     * receivers  (ECU Name)
     * attributes, _values, unit, comment
     * multiplex ('Multiplexor' or Number of Multiplex)
+    * short_name (if name exceeds normal length)
     """
 
     name = attr.ib(default="")  # type: str
@@ -108,6 +109,8 @@ class Signal(object):
             else value
         )
     )  # type: typing.Union[int, decimal.Decimal, None]
+
+    short_name = attr.ib(default="")  # type: str
 
     @offset.default
     def set_default_offset(self):

--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -985,6 +985,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
             signal.initial_value = (gen_sig_start_value * signal.factor) + signal.offset
             signal.cycle_time = int(signal.attributes.get("GenSigCycleTime", 0))
             if signal.attribute("SystemSignalLongSymbol") is not None:
+                signal.short_name = signal.name
                 signal.name = signal.attribute("SystemSignalLongSymbol")[1:-1]
                 signal.del_attribute("SystemSignalLongSymbol")
     for define in db.global_defines:


### PR DESCRIPTION
Currently, shortened signal names from the dbc are completely overwritten and inaccessible.  Put them on a new Signal attribute so callers can find them.