### PR TITLE
fix EDS Signal NameError

### DIFF
--- a/src/canmatrix/formats/eds.py
+++ b/src/canmatrix/formats/eds.py
@@ -52,7 +52,7 @@ def get_data_type_name(data_type_code):
 def format_index(index, subindex):
     return f"Index: 0x{index:04X}{subindex:02X}"
 
-def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatrix
+def load(f, **options):  # type: (typing.IO, **typing.Any) -> CanMatrix
     eds_import_encoding = options.get("edsImportEncoding", 'iso-8859-1')
     node_id = options.get("eds_node_id", 0)
     generic = options.get("generic", False)
@@ -242,7 +242,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
                     current_bit_start += bit_length
                     continue
                 signal_name = name_cleanup(mapped_obj.name)
-                new_sig = canmatrix.Signal(signal_name, size=bit_length, start_bit=current_bit_start)
+                new_sig = Signal(signal_name, size=bit_length, start_bit=current_bit_start)
                 datatype_name = get_data_type_name(mapped_obj.data_type)
                 if "UNSIGNED" in datatype_name:
                     new_sig.is_signed = False


### PR DESCRIPTION
Fix the following crash:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/.../python3.10/site-packages/canmatrix/cli/convert.py", line 163, in <module>
    sys.exit(cli_convert())
  File "/home/.../python3.10/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
  File "/home/.../python3.10/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/home/.../python3.10/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/.../python3.10/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/home/.../python3.10/site-packages/canmatrix/cli/convert.py", line 158, in cli_convert
    canmatrix.convert.convert(infile, outfile, **options)
  File "/home/.../python3.10/site-packages/canmatrix/convert.py", line 69, in convert
    dbs = canmatrix.formats.loadp(infile, **options)
  File "/home/.../python3.10/site-packages/canmatrix/formats/__init__.py", line 71, in loadp
    return load(fileObject, import_type, key, **options)
  File "/home/.../python3.10/site-packages/canmatrix/formats/__init__.py", line 94, in load
    dbs[key] = module_instance.load(file_object, **options)  # type: ignore
  File "/home/.../python3.10/site-packages/canmatrix/formats/eds.py", line 245, in load
    new_sig = canmatrix.Signal(signal_name, size=bit_length, start_bit=current_bit_start)
NameError: name 'canmatrix' is not defined. Did you mean: 'CanMatrix'?
```

Also, fix the type hint on `load()`.