### PR TITLE
Format exception when msg_id is None

### DIFF
--- a/src/canmatrix/Frame.py
+++ b/src/canmatrix/Frame.py
@@ -624,8 +624,12 @@ class Frame(object):
         rx_length = len(data)
         if rx_length != self.size:
             msg_id = self.arbitration_id.id if self.arbitration_id.id != 0 else self.header_id
-
-            logging.warning(f"Received message 0x{msg_id:08X} with length {rx_length}, expected {self.size}")
+            if msg_id is None:
+                msg_description = "nothing"
+            else:
+                msg_description = f"message 0x{msg_id:08X} with length {rx_length}"
+            msg = f"Received {msg_description}, expected {self.size}"
+            logging.warning(msg)
 
             if allow_truncated:
                 # pad the data with 0xff to prevent the codec from
@@ -638,8 +642,7 @@ class Frame(object):
 
             if len(data) != self.size:
                 # return None
-                raise DecodingFrameLength(
-                    f"Received message 0x{msg_id:04X} with wrong data size: {rx_length} instead of {self.size}")
+                raise DecodingFrameLength(f"{msg} (wrong data size)")
 
         if self.is_pdu_container:
             # note: PDU-Container without header is possible for ARXML-Container-PDUs with NO-HEADER


### PR DESCRIPTION
I don't know why or exactly how, but sometimes I hit a case here where msg_id is None, which breaks the hex formatting in the f-string.

<img width="1335" height="187" alt="image" src="https://github.com/user-attachments/assets/af9db4b5-80ab-42e2-8c34-7885155953be" />

This change will allow logging to happen as expected and the proper exception to raise if the wrong length frame is received.