### PR TITLE
Don't convert from phys to raw if BA_DEF_DEF_ "GenSigStartValue" is defined in DBC

### DIFF
--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -978,7 +978,7 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
         for signal in frame.signals:
             if "GenSigStartValue" in db.signal_defines \
                     and db.signal_defines["GenSigStartValue"].defaultValue is not None:
-                default_value = signal.phys2raw(float_factory(db.signal_defines["GenSigStartValue"].defaultValue))
+                default_value = float_factory(db.signal_defines["GenSigStartValue"].defaultValue)
             else:
                 default_value = signal.phys2raw(None)
             gen_sig_start_value = float_factory(signal.attributes.get("GenSigStartValue", default_value))

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -668,4 +668,3 @@ def test_env_var_with_val():
     assert var['values']['0'] == 'on'
     assert var['values']['1'] == 'off'
 
-    

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -559,7 +559,7 @@ def test_default_initial_value():
     ''').encode('utf-8'))
 
     matrix = canmatrix.formats.dbc.load(dbc, dbcImportEncoding="utf8")
-    assert matrix.frames[0].signals[0].initial_value == 10
+    assert matrix.frames[0].signals[0].initial_value == 5
 
 def test_keep_individual_inital_value():
     dbc = io.BytesIO(textwrap.dedent(u'''\

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -668,3 +668,4 @@ def test_env_var_with_val():
     assert var['values']['0'] == 'on'
     assert var['values']['1'] == 'off'
 
+    


### PR DESCRIPTION
conversion of DBC BA_DEF_DEF_ "GenSigStartValue"  will lead to wrong default value