### PR TITLE
fix(xls): reset signal_name on frame boundary to prevent first signal…

### DIFF
--- a/src/canmatrix/formats/xls.py
+++ b/src/canmatrix/formats/xls.py
@@ -423,6 +423,7 @@ def load(file, **options):
         # new frame detected
         if sh.cell(row_num, index['ID']).value != frame_id:
             # new Frame
+            signal_name = ""  # reset so the first signal of a new frame is never skipped
             frame_id = sh.cell(row_num, index['ID']).value
             frame_name = sh.cell(row_num, index['frameName']).value
             cycle_time = sh.cell(row_num, index['cycle']).value


### PR DESCRIPTION
## Problem

When two consecutive frames share the same signal name at the frame
boundary (e.g. frame A ends with "position" and frame B also starts
with "position"), the duplicate-detection guard

    if sh.cell(row_num, index['signalName']).value != signal_name

evaluates to False for the first signal of frame B, causing it to be
silently dropped from the output.

## Fix

Reset `signal_name` to `""` whenever a new frame is detected so the
first signal of every frame is always processed correctly.

## Reproduction

Define two consecutive messages where the last signal of message A and
the first signal of message B have the same name. The first signal of
message B will be missing from the generated DBC.
