### PR TITLE
Tolerate extra whitespace in INT/HEX/FLOAT attribute defines

### DIFF
--- a/src/canmatrix/Define.py
+++ b/src/canmatrix/Define.py
@@ -60,7 +60,7 @@ class Define(object):
         # for any known type:
         if definition[0:3] == 'INT':
             self.type = 'INT'
-            min, max = definition[4:].split(' ', 2)
+            min, max = definition.split()[1:3]
             self.min = safe_convert_str_to_int(min)
             self.max = safe_convert_str_to_int(max)
 
@@ -79,13 +79,13 @@ class Define(object):
 
         elif definition[0:3] == 'HEX':  # differently rendered in DBC editor, but values are saved like for an INT
             self.type = 'HEX'
-            min, max = definition[4:].split(' ', 2)
+            min, max = definition.split()[1:3]
             self.min = safe_convert_str_to_int(min)
             self.max = safe_convert_str_to_int(max)
 
         elif definition[0:5] == 'FLOAT':
             self.type = 'FLOAT'
-            min, max = definition[6:].split(' ', 2)
+            min, max = definition.split()[1:3]
             self.min = DefaultFloatFactory(min)
             self.max = DefaultFloatFactory(max)
 

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -42,6 +42,29 @@ def test_long_signal_name_imports():
     assert name_found is True
 
 
+def test_extra_whitespace_frame_define_roundtrips():
+    # A BA_DEF_ written with extra whitespace between tokens (as real exporters
+    # emit) must not be silently dropped on import; otherwise the per-frame BA_
+    # attribute is kept and dump() later raises KeyError on the missing define.
+    dbc = io.BytesIO(textwrap.dedent(u'''\
+    BO_ 2147483648 FDFrame: 8 TEST_ECU
+     SG_ sig1 : 0|8@1+ (1,0) [0|255] "" TEST_ECU
+
+    BA_DEF_ BO_  "VFrameFormat" INT  0 15;
+    BA_DEF_DEF_  "VFrameFormat" 0;
+    BA_ "VFrameFormat" BO_ 2147483648 15;
+    ''').encode('utf-8'))
+
+    matrix = canmatrix.formats.dbc.load(dbc)
+    assert "VFrameFormat" in matrix.frame_defines
+    assert matrix.frame_defines["VFrameFormat"].type == "INT"
+
+    out = io.BytesIO()
+    canmatrix.formats.dump(matrix, out, "dbc")  # previously raised KeyError
+    reloaded = canmatrix.formats.dbc.load(io.BytesIO(out.getvalue()))
+    assert "VFrameFormat" in reloaded.frame_defines
+
+
 def test_create_define():
     defaults = {}
     test_string = canmatrix.formats.dbc.create_define("my_data_type", Define('ENUM "A","B"'), "BA_", defaults)

--- a/tests/unit/test_Define.py
+++ b/tests/unit/test_Define.py
@@ -96,3 +96,22 @@ def test_define_for_float():
     assert define.type == "FLOAT"
     assert define.min == decimal.Decimal('-2.2')
     assert define.max == decimal.Decimal('111.11')
+
+
+@pytest.mark.parametrize("definition,exp_type,exp_min,exp_max", [
+    ("INT 0 15", "INT", 0, 15),
+    ("INT  0 15", "INT", 0, 15),          # extra space between type and value
+    ("INT   -5   10", "INT", -5, 10),     # irregular spacing, negative value
+    ("HEX 0 255", "HEX", 0, 255),
+    ("HEX  0 255", "HEX", 0, 255),
+    ("FLOAT 0 1.5", "FLOAT", 0, decimal.Decimal('1.5')),
+    ("FLOAT  -2.5 2.5", "FLOAT", decimal.Decimal('-2.5'), decimal.Decimal('2.5')),
+])
+def test_define_tolerates_extra_whitespace(definition, exp_type, exp_min, exp_max):
+    # Vector/CANdb DBC exporters emit extra spaces between tokens. The value
+    # splitter must not assume a single space; otherwise "INT  0 15" raised
+    # ValueError and the define was silently dropped on DBC import.
+    define = Define(definition)
+    assert define.type == exp_type
+    assert define.min == exp_min
+    assert define.max == exp_max


### PR DESCRIPTION
### The bug

`Define.__init__` crashes on a valid DBC `BA_DEF_` INT/HEX/FLOAT declaration that contains extra whitespace between tokens — which is exactly what Vector/CANdb exporters emit:

```python
>>> from canmatrix.Define import Define
>>> Define("INT  0 15")          # note the double space
ValueError: too many values to unpack (expected 2)
```

In the DBC importer this `ValueError` is swallowed by a bare `except` (`dbc.py`), so the frame define is **silently dropped** while the matching per-frame `BA_ "VFrameFormat" BO_ … 15` attribute is kept. A subsequent `formats.dump(matrix, …, "dbc")` then dies looking the define up:

```
File ".../canmatrix/formats/dbc.py", line 402, in dump
    ... db.frame_defines[attrib].type == "STRING" ...
KeyError: 'VFrameFormat'
```

So a CAN-FD DBC that loaded fine cannot be written back out.

### Why the expected result is unambiguous

- DBC is whitespace-tolerant between tokens, and canmatrix's **own** sibling regexes already allow one-or-more spaces, e.g. `dbc.py`: `r"^BA_DEF_ +\"(.+?)\" +(.+) *;"`. The parser correctly extracts `("VFrameFormat", "INT  0 15")`; only the `Define` value-splitter assumes a single space.
- The single-space form `"INT 0 15"` parses correctly, so the double-space form must too. `cantools` loads the identical file (its own `fd_test_int.dbc` fixture uses this spacing) without issue.

### Root cause

`src/canmatrix/Define.py`, in `Define.__init__` for the INT/HEX/FLOAT branches:

```python
min, max = definition[4:].split(' ', 2)     # INT / HEX
min, max = definition[6:].split(' ', 2)     # FLOAT
```

These strip the type keyword by a fixed offset and split on single spaces with `maxsplit=2`; for `"INT  0 15"`, `definition[4:]` is `" 0 15"` and `split(' ', 2)` yields `['', '0', '15']` (three items) → unpack error. The fix splits on arbitrary whitespace and takes the two value tokens (the type keyword is token 0), which is identical for the well-formed case and robust to extra spacing:

```python
min, max = definition.split()[1:3]
```

### Tests

- `tests/unit/test_Define.py::test_define_tolerates_extra_whitespace` — parametrized INT/HEX/FLOAT with single, double and irregular spacing (and negative values), asserting `type`/`min`/`max`.
- `tests/test_dbc.py::test_extra_whitespace_frame_define_roundtrips` — the end-to-end path: a CAN-FD DBC with a double-spaced `BA_DEF_` loads with the define **present**, then `dump()` (which used to `KeyError`) succeeds and reloads cleanly.

The new cases fail on `development` and pass with the fix; full suite stays green (338 passed, 1 skipped).
