### PR TITLE
fix(dbc): preserve the NS_ new-symbols section on dbc to dbc conversion

### DIFF
--- a/src/canmatrix/CanMatrix.py
+++ b/src/canmatrix/CanMatrix.py
@@ -102,6 +102,7 @@ class CanMatrix(object):
     value_tables = attr.ib(factory=dict)  # type: typing.MutableMapping[str, typing.MutableMapping]
     env_vars = attr.ib(factory=dict)  # type: typing.MutableMapping[str, typing.MutableMapping]
     signals = attr.ib(factory=list)  # type: typing.MutableSequence[Signal]
+    new_symbols = attr.ib(factory=list)  # type: typing.MutableSequence[str]
     baudrate = attr.ib(default=0)  # type:int
     fd_baudrate = attr.ib(default=0)  # type:int
     vlan = attr.ib(default=None)  # type:int

--- a/src/canmatrix/formats/dbc.py
+++ b/src/canmatrix/formats/dbc.py
@@ -171,7 +171,8 @@ def dump(in_db, f, **options):
             db.env_vars[env_var_name[:32]] = db.env_vars.pop(env_var_name)
             db.add_env_defines("SystemEnvVarLongSymbol", "STRING")
 
-    header = "VERSION \"created by canmatrix\"\n\n\nNS_ :\n\nBS_:\n\n"
+    new_symbols = "".join("    " + symbol + "\n" for symbol in db.new_symbols)
+    header = "VERSION \"created by canmatrix\"\n\n\nNS_ :\n" + new_symbols + "\nBS_:\n\n"
     f.write(header.encode(dbc_export_encoding, ignore_encoding_errors))
 
     # ECUs
@@ -478,7 +479,7 @@ def dump(in_db, f, **options):
 
 
 class _FollowUps(object):
-    NOTHING, SIGNAL_COMMENT, FRAME_COMMENT, BOARD_UNIT_COMMENT, GLOBAL_COMMENT = range(5)
+    NOTHING, SIGNAL_COMMENT, FRAME_COMMENT, BOARD_UNIT_COMMENT, GLOBAL_COMMENT, NEW_SYMBOLS = range(6)
 
 
 def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatrix
@@ -547,6 +548,16 @@ def load(f, **options):  # type: (typing.IO, **typing.Any) -> canmatrix.CanMatri
                         board_unit.add_comment(comment[:-1].strip()[:-1])
                 continue
             decoded = l.decode(dbc_import_encoding).strip()
+            if follow_up == _FollowUps.NEW_SYMBOLS:
+                # the NS_ section lists bare symbol names, one per line, until
+                # the next section keyword (usually BS_:) starts.
+                if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", decoded):
+                    db.new_symbols.append(decoded)
+                    continue
+                follow_up = _FollowUps.NOTHING
+            if decoded.startswith("NS_ ") or decoded == "NS_:":
+                follow_up = _FollowUps.NEW_SYMBOLS
+                continue
             if decoded.startswith("BO_ "):
                 regexp = re.compile(r"^BO_ ([^\ ]+) ([^\ ]+) *: *([^\ ]+) ([^\ ]+)")
                 temp = regexp.match(decoded)

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -65,6 +65,37 @@ def test_extra_whitespace_frame_define_roundtrips():
     assert "VFrameFormat" in reloaded.frame_defines
 
 
+def test_new_symbols_section_roundtrips():
+    # The NS_ ("new symbols") section lists the DBC keywords a file uses. It was
+    # never parsed, and dump() always wrote an empty NS_ :, so a dbc->dbc
+    # conversion silently dropped the whole section.
+    dbc = io.BytesIO(textwrap.dedent(u'''\
+    VERSION "test"
+
+
+    NS_ :
+        NS_DESC_
+        CM_
+        BA_DEF_
+        BA_
+
+    BS_:
+
+    BU_: TEST_ECU
+
+    BO_ 100 TestFrame: 8 TEST_ECU
+     SG_ sig1 : 0|8@1+ (1,0) [0|255] "" TEST_ECU
+    ''').encode('utf-8'))
+
+    matrix = canmatrix.formats.dbc.load(dbc)
+    assert matrix.new_symbols == ["NS_DESC_", "CM_", "BA_DEF_", "BA_"]
+
+    out = io.BytesIO()
+    canmatrix.formats.dump(matrix, out, "dbc")
+    reloaded = canmatrix.formats.dbc.load(io.BytesIO(out.getvalue()))
+    assert reloaded.new_symbols == ["NS_DESC_", "CM_", "BA_DEF_", "BA_"]
+
+
 def test_create_define():
     defaults = {}
     test_string = canmatrix.formats.dbc.create_define("my_data_type", Define('ENUM "A","B"'), "BA_", defaults)


### PR DESCRIPTION
Closes #557

The `NS_` (new symbols) section was never parsed on import, and `dump()` always wrote a hardcoded empty `NS_ :` header, so a dbc -> dbc conversion or merge silently dropped the whole section.

`CanMatrix` now carries a `new_symbols` list, the loader collects the bare symbol names following `NS_` until the next section keyword, and `dump()` writes them back.

`tests/test_dbc.py::test_new_symbols_section_roundtrips` fails on current `development` (`AttributeError: 'CanMatrix' object has no attribute 'new_symbols'`) and passes with the fix; the rest of the suite is unchanged.
